### PR TITLE
Add collection data for Derage by Darkfarms1

### DIFF
--- a/collections/derage-darkfarms1/inscriptions.json
+++ b/collections/derage-darkfarms1/inscriptions.json
@@ -1,526 +1,526 @@
 [
   {
     "id": "41dbdbd7db4004cb55e02ea5cbb7d138a22869e021e71d5c4ecd15ef8bf1979ai0", 
-    "meta": { "name": "Derage #1" } 
+    "meta": { "name": "Derage#14" } 
   },
   {
     "id": "0ddc35dafa93cbc7e2cddfc5ba81ae57d159703eafcd39f5390f139b7cc24abei0", 
-    "meta": { "name": "Derage #2" } 
+    "meta": { "name": "Derage#3019" } 
   },
   {
     "id": "6b0a29468645fb6f9f5de44ffc354dc7d058e0611cbef1e0f01bc1062a3c6b30i0", 
-    "meta": { "name": "Derage #3" } 
+    "meta": { "name": "Derage#1500" } 
   },
   {
     "id": "32b0257fd79ec827e8826939c8a04a17f214769bf66d75342294acb3cead45e1i0", 
-    "meta": { "name": "Derage #4" } 
+    "meta": { "name": "Derage#2800" } 
   },
   {
     "id": "cb9dc764382b823459e1aff6e4a8e29bda314d71608f7cc494e774befa2f03eci0", 
-    "meta": { "name": "Derage #5" } 
+    "meta": { "name": "Derage#4058" } 
   },
   {
     "id": "ef137a87e457e2ba54f090fbee300d92decbd90567d351f5b5e15bc67cb8fbc7i0", 
-    "meta": { "name": "Derage #6" } 
+    "meta": { "name": "Derage#3828" } 
   },
   {
     "id": "c042c1182dfb8d884229140e35d405f154395e87ee53e596664ab5e6ccbaf605i0", 
-    "meta": { "name": "Derage #7" } 
+    "meta": { "name": "Derage#3464" } 
   },
   {
     "id": "5cecbad09f7df8b5a4f5b298dfe91e32094275960d2e8fffb6c3ad1e99def737i0", 
-    "meta": { "name": "Derage #8" } 
+    "meta": { "name": "Derage#4133" } 
   },
   {
     "id": "5f5b828490c534e39920f9196c6f1fdbe1bcb272fd7efade3fee1505b767befdi0", 
-    "meta": { "name": "Derage #9" } 
+    "meta": { "name": "Derage#416" } 
   },
   {
     "id": "e9e38342a8a25d997b396368910d7595ba8757d53a25d321b04a87511ef6f882i0", 
-    "meta": { "name": "Derage #10" } 
+    "meta": { "name": "Derage#511" } 
   },
   {
     "id": "76625761deb9925420e9ca1d4cb4356aca0d8807dc92ed350303984a6ffcc992i0", 
-    "meta": { "name": "Derage #11" } 
+    "meta": { "name": "Derage#857" } 
   },
   {
     "id": "31b4057aad120722e42419b4166c9e7eafb80933650661a24ae95f2100b657d7i0", 
-    "meta": { "name": "Derage #12" } 
+    "meta": { "name": "Derage#3060" } 
   },
   {
     "id": "47727ffee6bc15593e318755a49fb481025c6c7028427b71225cbcb21ccbbcf3i0", 
-    "meta": { "name": "Derage #13" } 
+    "meta": { "name": "Derage#2618" } 
   },
   {
     "id": "b4ddb4e48e82bf5f1ef5845bf23b22f560359a33ef102d72c1f5d7ef308372e1i0", 
-    "meta": { "name": "Derage #14" } 
+    "meta": { "name": "Derage#1451" } 
   },
   {
     "id": "7cdc0d79f8ff3ec742fd1fa7ff6d474134f3a2837b71c9f7e1523f78e20d5002i0", 
-    "meta": { "name": "Derage #15" } 
+    "meta": { "name": "Derage#2843" } 
   },
   {
     "id": "84b24cacb21f2f25ff64f550d12c44acbb683f5308f87aaeb1259d3fe94ba184i0", 
-    "meta": { "name": "Derage #16" } 
+    "meta": { "name": "Derage#251" } 
   },
   {
     "id": "48b2c1bf110b8eb42dd597758efd54f94cc4beac0687907fc14588fdd89cb083i0", 
-    "meta": { "name": "Derage #17" } 
+    "meta": { "name": "Derage#4028" } 
   },
   {
     "id": "d9a1f3af2144fc976de04a818ff2c3f73e766b4312a34828b305144cfddeada6i0", 
-    "meta": { "name": "Derage #18" } 
+    "meta": { "name": "Derage#3116" } 
   },
   {
     "id": "abbdc4643714b80413b54983572d728484ffba8f14d7c2d636d76a3b31e09c96i0", 
-    "meta": { "name": "Derage #19" } 
+    "meta": { "name": "Derage#2021" } 
   },
   {
     "id": "00b668a69235389957f2056570aaaba1942d3e134deaea5f0c1a0cdd219455e7i0", 
-    "meta": { "name": "Derage #20" } 
+    "meta": { "name": "Derage#3815" } 
   },
   {
     "id": "9c36cd9b47767da245260971e4c1bf1ed0cb0db96a21100d962cdd67003f065fi0", 
-    "meta": { "name": "Derage #21" } 
+    "meta": { "name": "Derage#1522" } 
   },
   {
     "id": "0e1f9966330c12378de49a294da85e51f357fea52699629076bceaa5a26c684bi0", 
-    "meta": { "name": "Derage #22" } 
+    "meta": { "name": "Derage#586" } 
   },
   {
     "id": "1efba544121505b654ab14dcc2abaf38aac137de1fba8664ba22612dcd621888i0", 
-    "meta": { "name": "Derage #23" } 
+    "meta": { "name": "Derage#3543" } 
   },
   {
     "id": "c07b3398edf59ff78030e4afa4dba79e32c660d0f971527a1b5014c7af679712i0", 
-    "meta": { "name": "Derage #24" } 
+    "meta": { "name": "Derage#4030" } 
   },
   {
     "id": "9564680ed4afcd36af32988e6687fa17fee92fb5becadaecbab41f80da6e4eb9i0", 
-    "meta": { "name": "Derage #25" } 
+    "meta": { "name": "Derage#2009" } 
   },
   {
     "id": "5d943b922516bcde5e35ad7502160095e0fb7fce8ee8d00d669811d1604bd4b8i0", 
-    "meta": { "name": "Derage #26" } 
+    "meta": { "name": "Derage#591" } 
   },
   {
     "id": "549ae97155d16f790b86cc35ab8e3e010cf3c6b776d3e27ab7fc913750647ad1i0", 
-    "meta": { "name": "Derage #27" } 
+    "meta": { "name": "Derage#4016" } 
   },
   {
     "id": "8d4413c4d5627639bf27a3b17521908ab659b4cb4c94e7c8439504849f165e02i0", 
-    "meta": { "name": "Derage #28" } 
+    "meta": { "name": "Derage#2919" } 
   },
   {
     "id": "1aeec63ffd3516500284f7b5b55581bfbace10b34c0be41d2c84e6494a77355ci0", 
-    "meta": { "name": "Derage #29" } 
+    "meta": { "name": "Derage#1323" } 
   },
   {
     "id": "e7439b59bdf935d4020150093d034bacb4605443d38f25f416e0be706bd32fd7i0", 
-    "meta": { "name": "Derage #30" } 
+    "meta": { "name": "Derage#4020" } 
   },
   {
     "id": "8691ea2ae9d2a87e9e444f9ffa16115397fbb124f47a8ecb0a6b5a93d5cb109ei0", 
-    "meta": { "name": "Derage #31" } 
+    "meta": { "name": "Derage#1763" } 
   },
   {
     "id": "9e27b23abc24a1b7a2682ebd3530538abe4388c1f41a3da196d977d6ac7b933fi0", 
-    "meta": { "name": "Derage #32" } 
+    "meta": { "name": "Derage#259" } 
   },
   {
     "id": "a75548884d72d40864eccd6046cfe41807040997e3aad2bd594602f9bd49914di0", 
-    "meta": { "name": "Derage #33" } 
+    "meta": { "name": "Derage#170" } 
   },
   {
     "id": "0d40e925978aabe2331f625af695a4ed21710f0c44bb820f18df13ac3f97ee09i0", 
-    "meta": { "name": "Derage #34" } 
+    "meta": { "name": "Derage#897" } 
   },
   {
     "id": "d4f8fefcefa7dac19ac4fbc5d6b19d5f4fd2f76465dbacddc3dad791f1b82e54i0", 
-    "meta": { "name": "Derage #35" } 
+    "meta": { "name": "Derage#1259" } 
   },
   {
     "id": "2897353223683cb8d5b27e2cbfb245bac5a523284fa808c11e082136d54978c2i0", 
-    "meta": { "name": "Derage #36" } 
+    "meta": { "name": "Derage#2520" } 
   },
   {
     "id": "73a07680f51f5e8c576b18ff5fae6517245c1240af937a06f56992a64f4d44b5i0", 
-    "meta": { "name": "Derage #37" } 
+    "meta": { "name": "Derage#3076" } 
   },
   {
     "id": "502a991a92811bc4b6bdafddb57e1343befa113e23e8227dabcc2335b50a9c12i0", 
-    "meta": { "name": "Derage #38" } 
+    "meta": { "name": "Derage#3435" } 
   },
   {
     "id": "c59108cd178e2f5ccc6dec8a78b935b4ba4f7e7bc1ca24ac79b388708b136c9ci0", 
-    "meta": { "name": "Derage #39" } 
+    "meta": { "name": "Derage#1946" } 
   },
   {
     "id": "4a58861cdaada7ae0b84175ac0c047988e91b6cd2f63fe8b503c4a0900a9ad1ei0", 
-    "meta": { "name": "Derage #40" } 
+    "meta": { "name": "Derage#387" } 
   },
   {
     "id": "d4c9443ca645b3f58a2dbcdbc0e9ffdb2373ea33789167eacf508df143e96445i0", 
-    "meta": { "name": "Derage #41" } 
+    "meta": { "name": "Derage#3110" } 
   },
   {
     "id": "7410f521ed033e748c613143063f2bac2d750b518f8a0a96d2981565bed4598fi0", 
-    "meta": { "name": "Derage #42" } 
+    "meta": { "name": "Derage#1681" } 
   },
   {
     "id": "fe8efe7bb0e8d1a74540904a0e28f544011aaf3ca4e9d83e48f16d55cf0e5a7ai0", 
-    "meta": { "name": "Derage #43" } 
+    "meta": { "name": "Derage#3689" } 
   },
   {
     "id": "0d73ea6de24b6d4fd68f56d6a9d2d51a044d99b6db9fdd90f642cf31b8994ae0i0", 
-    "meta": { "name": "Derage #44" } 
+    "meta": { "name": "Derage#3248" } 
   },
   {
     "id": "08e331203c443a0ad9a3069fba44bda4b1bc5b1504bc339b2af7b84a8e316c76i0", 
-    "meta": { "name": "Derage #45" } 
+    "meta": { "name": "Derage#979" } 
   },
   {
     "id": "5990095b438c8c39dbc0c535b317e3c5e7a1decfbae624cb63354c152fe989bdi0", 
-    "meta": { "name": "Derage #46" } 
+    "meta": { "name": "Derage#3398" } 
   },
   {
     "id": "4ad8f0324d4a68ef3b633f1e2660300bdb58ccc54b836ca89346e9f0589069a0i0", 
-    "meta": { "name": "Derage #47" } 
+    "meta": { "name": "Derage#2141" } 
   },
   {
     "id": "0c4942e77a68ebb281b229527f65191b50e21404675da5abae436951532f03f7i0", 
-    "meta": { "name": "Derage #48" } 
+    "meta": { "name": "Derage#3340" } 
   },
   {
     "id": "8b49caf1ea1e74ccda38fb8c5ac12015381e2a8323bc79221ff929dbe85b4a8fi0", 
-    "meta": { "name": "Derage #49" } 
+    "meta": { "name": "Derage#1587" } 
   },
   {
     "id": "32348e3c5561c1046dad7e3f30ea5f12b924bb140cbb2dc92e2a658653fe2686i0", 
-    "meta": { "name": "Derage #50" } 
+    "meta": { "name": "Derage#3434" } 
   },
   {
     "id": "0969d34ae7ea16c23901eb5d9ca0475f910510d67ac460578421559a4026381ai0", 
-    "meta": { "name": "Derage #51" } 
+    "meta": { "name": "Derage#3744" } 
   },
   {
     "id": "0e67b5effb0d137021bd90ead4a0864f5a150bb925a638ed7ceaf28a3289c755i0", 
-    "meta": { "name": "Derage #52" } 
+    "meta": { "name": "Derage#39" } 
   },
   {
     "id": "f8c3737f80b04108116a01286a4488a3711a39c6a01cdaabb3196a598389a88ei0", 
-    "meta": { "name": "Derage #53" } 
+    "meta": { "name": "Derage#1112" } 
   },
   {
     "id": "a3828cdcde37b5ab8360fddadb8c94bb8b06d555b8ac8bf237777aa4c9dac307i0", 
-    "meta": { "name": "Derage #54" } 
+    "meta": { "name": "Derage#9" } 
   },
   {
     "id": "fc1f8023cbff820220404f6b31738cf98684311c701f94cf13b214f054a53052i0", 
-    "meta": { "name": "Derage #55" } 
+    "meta": { "name": "Derage#417" } 
   },
   {
     "id": "e36ac4655f2c6817bede7bfc26a0ffe3b7eb26f160a3f99dbaac720eae19e8e9i0", 
-    "meta": { "name": "Derage #56" } 
+    "meta": { "name": "Derage#495" } 
   },
   {
     "id": "f7d35a929be7879bc37256fce75bee214f849314ea28d44ce8d406da28aa56e2i0", 
-    "meta": { "name": "Derage #57" } 
+    "meta": { "name": "Derage#1851" } 
   },
   {
     "id": "02f63aec5c45b905eb61dbf4cef4e262f75e12b9e4f62e20e872198cb2a3263bi0", 
-    "meta": { "name": "Derage #58" } 
+    "meta": { "name": "Derage#2232" } 
   },
   {
     "id": "78563702aae741392adbac12c892fd1737403f78b49a4dba3bb6f38f3283b47di0", 
-    "meta": { "name": "Derage #59" } 
+    "meta": { "name": "Derage#67" } 
   },
   {
     "id": "45d51bf2fa4a6892209f2051a8993617b884619dd629b7f84d6708829d146a01i0", 
-    "meta": { "name": "Derage #60" } 
+    "meta": { "name": "Derage#2228" } 
   },
   {
     "id": "0262b0e771bae5a07103504218a64d38e06ad1ab693603bbe6259548ef0f6b7bi0", 
-    "meta": { "name": "Derage #61" } 
+    "meta": { "name": "Derage#2670" } 
   },
   {
     "id": "77c381a9d93e757c233795da39035be11ef5cfd727acc69b394993b528742ae1i0", 
-    "meta": { "name": "Derage #62" } 
+    "meta": { "name": "Derage#3592" } 
   },
   {
     "id": "ef39effde59d199509b798bbe2077ead7da128c134d5ebb4b7619ea7d0888ff4i0", 
-    "meta": { "name": "Derage #63" } 
+    "meta": { "name": "Derage#599" } 
   },
   {
     "id": "1be3eca328a0a5e5788fa38c611d593003aebbb0b645e6d55cb65526a68304b1i0", 
-    "meta": { "name": "Derage #64" } 
+    "meta": { "name": "Derage#169" } 
   },
   {
     "id": "6184eddccd911b4df7aa951abad4333340a97b5c8ad20994aef2f8067c061cb5i0", 
-    "meta": { "name": "Derage #65" } 
+    "meta": { "name": "Derage#3609" } 
   },
   {
     "id": "cfc177d2cbc41eb478aa47747f184d57c78cee1d0821a7b5be4a0369f057ec87i0", 
-    "meta": { "name": "Derage #66" } 
+    "meta": { "name": "Derage#1453" } 
   },
   {
     "id": "fc203bb5dba964176d704f8b400cbf81ff01ac50e42f446e49d6f63b72b07ab1i0", 
-    "meta": { "name": "Derage #67" } 
+    "meta": { "name": "Derage#345" } 
   },
   {
     "id": "977995788d8d3f6ae0af6669758325eb53165ee87e64018ab525e9f3b614d14ci0", 
-    "meta": { "name": "Derage #68" } 
+    "meta": { "name": "Derage#2940" } 
   },
   {
     "id": "5a77396bbfad72ab48eb15e5091e9f02e893ce8c2369c9f73a9e9ae8b5dc0898i0", 
-    "meta": { "name": "Derage #69" } 
+    "meta": { "name": "Derage#3246" } 
   },
   {
     "id": "2e5d930a65dbd79fcea45b699986c0a723206bc3e7b6d166cc60c23d87988e51i0", 
-    "meta": { "name": "Derage #70" } 
+    "meta": { "name": "Derage#2304" } 
   },
   {
     "id": "4abc2b0c9456cc4ebc54578ec142d033a2bfc8b17ed89ac8bfdba2189d7d49a4i0", 
-    "meta": { "name": "Derage #71" } 
+    "meta": { "name": "Derage#1905" } 
   },
   {
     "id": "7e93612f9cd8b2596c8e8392b2ae562c252e32a5979b4ec3d0ac4029f894bfabi0", 
-    "meta": { "name": "Derage #72" } 
+    "meta": { "name": "Derage#48" } 
   },
   {
     "id": "1f0d7e073091c08bd5ce45e076f6749374e6217c13fa75a6e00a29ccaba3c7b6i0", 
-    "meta": { "name": "Derage #73" } 
+    "meta": { "name": "Derage#3452" } 
   },
   {
     "id": "d330e13c31daed33b136457a7516e2184c035bfeead4e814e485ff4eb4473324i0", 
-    "meta": { "name": "Derage #74" } 
+    "meta": { "name": "Derage#2083" } 
   },
   {
     "id": "8620a62219fb7a2f317a51c33169eed1eabccd5addea5fc8cf165bdb7951c8afi0", 
-    "meta": { "name": "Derage #75" } 
+    "meta": { "name": "Derage#2651" } 
   },
   {
     "id": "6b9e0ba33868f06f3fbaf7c707bf9cfa0e390a5548be04782be983fb1418c2f4i0", 
-    "meta": { "name": "Derage #76" } 
+    "meta": { "name": "Derage#2840" } 
   },
   {
     "id": "88a980419beb2d260e95be9fb6d5ea220b73ec7dc97d74bed83c323b140d5cbai0", 
-    "meta": { "name": "Derage #77" } 
+    "meta": { "name": "Derage#2570" } 
   },
   {
     "id": "de0c1ed7b9c526edd7069701337b3c225d1544807ff79501f2ee86108e411fb1i0", 
-    "meta": { "name": "Derage #78" } 
+    "meta": { "name": "Derage#4164" } 
   },
   {
     "id": "519bef447de4779d7c2bc767740e99072d5389acfd8ff72be4cf6b1cc9223aadi0", 
-    "meta": { "name": "Derage #79" } 
+    "meta": { "name": "Derage#3135" } 
   },
   {
     "id": "2632b255fd64db58997e32fef27d5b086afe4a578788869cc835a0370f2ee3bdi0", 
-    "meta": { "name": "Derage #80" } 
+    "meta": { "name": "Derage#2619" } 
   },
   {
     "id": "7cfb5187ea08519471fdcbb4b6a325dafdc14234c8697538a7d11d120be34711i0", 
-    "meta": { "name": "Derage #81" } 
+    "meta": { "name": "Derage#81" } 
   },
   {
     "id": "9676f64ac82967acaeea3c3b07acfd4865ebb23a3dd270d15dfc4399dfb4f4dci0", 
-    "meta": { "name": "Derage #82" } 
+    "meta": { "name": "Derage#1710" } 
   },
   {
     "id": "389947db475b3eabffa1396073b522095842ac3842c07a340a66f3059c3c5264i0", 
-    "meta": { "name": "Derage #83" } 
+    "meta": { "name": "Derage#1641" } 
   },
   {
     "id": "93a8f5bb6cdda630bd4f1bdc8aab7d41ad679279c69f40694c100f78105c68ffi0", 
-    "meta": { "name": "Derage #84" } 
+    "meta": { "name": "Derage#2806" } 
   },
   {
     "id": "b9528874bc5d8b0d25a41c6f3395b72794356c02086c1357e8e3da6f3f2ffb89i0", 
-    "meta": { "name": "Derage #85" } 
+    "meta": { "name": "Derage#278" } 
   },
   {
     "id": "41127eceb8a5f14895100f8364b60036e37d1d271bff65c435859033b306a581i0", 
-    "meta": { "name": "Derage #86" } 
+    "meta": { "name": "Derage#844" } 
   },
   {
     "id": "47b7f19d1615a76e2877851393f3fb1d81ee1377e05a3b66f4b206bb8684a9d9i0", 
-    "meta": { "name": "Derage #87" } 
+    "meta": { "name": "Derage#1997" } 
   },
   {
     "id": "b81c119641a3ace5283cc3e5638591568706a3fcdc5d98ddcc828f64d3a68d88i0", 
-    "meta": { "name": "Derage #88" } 
+    "meta": { "name": "Derage#1921" } 
   },
   {
     "id": "090c57805d32f439b70ebbac6c12675b22ffbec0f0e151d47b56b1a55c1e00c1i0", 
-    "meta": { "name": "Derage #89" } 
+    "meta": { "name": "Derage#605" } 
   },
   {
     "id": "c354fc8c45b0652f94190a79c23e21bc3de26005c21696d5df0ccd8610e791c4i0", 
-    "meta": { "name": "Derage #90" } 
+    "meta": { "name": "Derage#606" } 
   },
   {
     "id": "fc2acbf2717f7a7108041cf09e05065cd8b9f94655d3b84699c482cb0cc3e7e9i0", 
-    "meta": { "name": "Derage #91" } 
+    "meta": { "name": "Derage#3440" } 
   },
   {
     "id": "cbd57c016526dfded1a52be59e41cc56e2b36f59a00166dada9b5ca3fec5fb33i0", 
-    "meta": { "name": "Derage #92" } 
+    "meta": { "name": "Derage#3127" } 
   },
   {
     "id": "e15b0102bc63efe43842a387bcde0feaf400521b72a5c8134026377121467fafi0", 
-    "meta": { "name": "Derage #93" } 
+    "meta": { "name": "Derage#286" } 
   },
   {
     "id": "16ad7bfb77e27b54f7321c7f80d6d4b48b39530abef367dad188183bfddfe274i0", 
-    "meta": { "name": "Derage #94" } 
+    "meta": { "name": "Derage#3979" } 
   },
   {
     "id": "7eba1e5bf5291b4da4a8ec678e96604f189183347f159d50077d7b545c8071c4i0", 
-    "meta": { "name": "Derage #95" } 
+    "meta": { "name": "Derage#3856" } 
   },
   {
     "id": "7430f52e4706d9ea69a522125fca9095b7a781f32e9096cc12aaf02245ba34a1i0", 
-    "meta": { "name": "Derage #96" } 
+    "meta": { "name": "Derage#2310" } 
   },
   {
     "id": "ab8647df4f58002375ec3dcd410b01235146e95ad5ad2784bb9cc005c0fc774bi0", 
-    "meta": { "name": "Derage #97" } 
+    "meta": { "name": "Derage#3131" } 
   },
   {
     "id": "3ce9cb700ee014c0feb24bac3a640f370916e792f6780fad7be3d417e7a367e6i0", 
-    "meta": { "name": "Derage #98" } 
+    "meta": { "name": "Derage#1505" } 
   },
   {
     "id": "d299a766178ad719750fca35f9cd08940ecbeb1318bbc5ba2c7e3aefb0542234i0", 
-    "meta": { "name": "Derage #99" } 
+    "meta": { "name": "Derage#2878" } 
   },
   {
     "id": "e19cac165c0ded27ae1791319cc4c47162218a68510a6dd347373f185cd9edebi0", 
-    "meta": { "name": "Derage #100" } 
+    "meta": { "name": "Derage#1525" } 
   },
   {
     "id": "a95717837fa373517f3f0f4742b20548d69c2e27274037d8979ffff45d98fe81i0", 
-    "meta": { "name": "Derage #101" } 
+    "meta": { "name": "Derage#2087" } 
   },
   {
     "id": "e7a3a83539bbec8c88b0922eb3b5f6b15279e107dc30b6c73a95da99f42e3334i0", 
-    "meta": { "name": "Derage #102" } 
+    "meta": { "name": "Derage#1526" } 
   },
   {
     "id": "1c5df360bcbf04d78c918e6f4b1f6e328b3519d09b37e1761592086780fd330ei0", 
-    "meta": { "name": "Derage #103" } 
+    "meta": { "name": "Derage#1527" } 
   },
   {
     "id": "da10484fe2405550dd296e56f053c5e6649c094b0ab625f87970a0b44733c919i0", 
-    "meta": { "name": "Derage #104" } 
+    "meta": { "name": "Derage#2088" } 
   },
   {
     "id": "9dff6ebe0481db3f9fdc769f38bce72869feaffb6e97d9106f57fb5ce07a75d9i0", 
-    "meta": { "name": "Derage #105" } 
+    "meta": { "name": "Derage#2089" } 
   },
   {
     "id": "f086989138843807aab673c117236e2b3798ea87efbbbc8a656bae104aa4aa3bi0", 
-    "meta": { "name": "Derage #106" } 
+    "meta": { "name": "Derage#1364" } 
   },
   {
     "id": "9a259f87f18b090aab1ab87011f99a1a24cf79033c714acc94208a52931abb5fi0", 
-    "meta": { "name": "Derage #107" } 
+    "meta": { "name": "Derage#13" } 
   },
   {
     "id": "70ac3dbbea84cad1c19c03f1f574a6625d74507a8768c5ab84fe010fbe218b92i0", 
-    "meta": { "name": "Derage #108" } 
+    "meta": { "name": "Derage#746" } 
   },
   {
     "id": "12248f708a35f84d87059ec260ee20c8b9425c4b447627fa7f5ec73ca3db76eci0", 
-    "meta": { "name": "Derage #109" } 
+    "meta": { "name": "Derage#4015" } 
   },
   {
     "id": "a88b0f5416741ad90281d503d32afd50b89853f340c0e8f902ddc7878a4304fbi0", 
-    "meta": { "name": "Derage #110" } 
+    "meta": { "name": "Derage#3023" } 
   },
   {
     "id": "9a759f929bcb13fd30f1f95ed46b154a9b4d9a34c2decce2fd1d51b4aa2e674fi0", 
-    "meta": { "name": "Derage #111" } 
+    "meta": { "name": "Derage#3874" } 
   },
   {
     "id": "ea66aef7bd337a3e156c0494868cb4a526e5f81973fd95bc09bbfd107428f4ebi0", 
-    "meta": { "name": "Derage #112" } 
+    "meta": { "name": "Derage#3531" } 
   },
   {
     "id": "5dd9c4d96a859fb1dba068317adcdcb67f9d485880285e2af5a4e703b0c258dbi0", 
-    "meta": { "name": "Derage #113" } 
+    "meta": { "name": "Derage#2695" } 
   },
   {
     "id": "103097db1023b6deaa418ab0ec108f42a872e015d441da67920fdbe39c04e06ei0", 
-    "meta": { "name": "Derage #114" } 
+    "meta": { "name": "Derage#636" } 
   },
   {
     "id": "d1425d24c81d34ff438d8550f7dad2f67bbeab734bd5dba7a399dc1a59c5738di0", 
-    "meta": { "name": "Derage #115" } 
+    "meta": { "name": "Derage#2772" } 
   },
   {
     "id": "8a133ef3518aca49dbeec557b1fb78a5169e8bdd96927ac9f6864020ebb68040i0", 
-    "meta": { "name": "Derage #116" } 
+    "meta": { "name": "Derage#2174" } 
   },
   {
     "id": "d2474bb80873232c9f9c639f1dc56bde99ec4e764e55ff1c645a98518edf4db8i0", 
-    "meta": { "name": "Derage #117" } 
+    "meta": { "name": "Derage#4153" } 
   },
   {
     "id": "ddc5c956d3b5159f66fb6c6d7a243a4cb4d6399bd5a863390de256c137d8f475i0", 
-    "meta": { "name": "Derage #118" } 
+    "meta": { "name": "Derage#3145" } 
   },
   {
     "id": "758be59584c478a0912e2f2fbf98b141474ab321a7856a4f3693fc58cc78c59fi0", 
-    "meta": { "name": "Derage #119" } 
+    "meta": { "name": "Derage#2357" } 
   },
   {
     "id": "2163ec4119ffd115e2abfbc3e201ae4e6d46f72af3bcf20800af72ba123d8225i0", 
-    "meta": { "name": "Derage #120" } 
+    "meta": { "name": "Derage#1606" } 
   },
   {
     "id": "895c5c078717ed203140fdad4497fd7221a8c2d55e94a926928f11014577e892i0", 
-    "meta": { "name": "Derage #121" } 
+    "meta": { "name": "Derage#3129" } 
   },
   {
     "id": "3912a512f4eeb87415797c8cbb7f7c83d69dd3cdddf74ee2212af594e066030ei0", 
-    "meta": { "name": "Derage #122" } 
+    "meta": { "name": "Derage#4113" } 
   },
   {
     "id": "7441e94c9f6f4e5f5f0398e41deff9d9e69dc8b2e51798a387b1ec255813a6b6i0", 
-    "meta": { "name": "Derage #123" } 
+    "meta": { "name": "Derage#2636" } 
   },
   {
     "id": "a7793e2277997c77d20bfee6249a888f57744ea01bf495438b0ed461e83fc6c9i0", 
-    "meta": { "name": "Derage #124" } 
+    "meta": { "name": "Derage#1570" } 
   },
   {
     "id": "43447ee6412b0c0bc959e9e097f3fb0d1aed7fd49952477752a28670bcfc80aei0", 
-    "meta": { "name": "Derage #125" } 
+    "meta": { "name": "Derage#2757" } 
   },
   {
     "id": "dc5687ba1ef75180860eef8d978c309b4dc62d1e59f6f3e3180ee2851222ff4ei0", 
-    "meta": { "name": "Derage #126" } 
+    "meta": { "name": "Derage#85" } 
   },
   {
     "id": "48f1b671ef78d552b42b8fdb4182a8119483fe66b9db5d3c4d22f592357b5118i0", 
-    "meta": { "name": "Derage #127" } 
+    "meta": { "name": "Derage#199" } 
   },
   {
     "id": "8a5cb46fe048de6dfd46e3fca015edba2e985d30cbd92f0ed41c05c9929af6afi0", 
-    "meta": { "name": "Derage #128" } 
+    "meta": { "name": "Derage#2162" } 
   },
   {
     "id": "c070c442cac7dce87609533bbd67d864d066aef7fefd31d2d690cd82ef59afbai0", 
-    "meta": { "name": "Derage #129" } 
+    "meta": { "name": "Derage#1620" } 
   },
   {
     "id": "40acbe7abf61709042a9616cc2bd2eee177871f63f2fb50c80571cd041135dadi0", 
-    "meta": { "name": "Derage #130" } 
+    "meta": { "name": "Derage#1501" } 
   },
   {
     "id": "124dfc58426141a231d98bc7f62a300fae02bae8fc4502478a1e912621123f33i0", 
-    "meta": { "name": "Derage #131" } 
+    "meta": { "name": "Derage#1638" } 
   }
 ]

--- a/collections/derage-darkfarms1/inscriptions.json
+++ b/collections/derage-darkfarms1/inscriptions.json
@@ -1,0 +1,526 @@
+[
+  {
+    "id": "41dbdbd7db4004cb55e02ea5cbb7d138a22869e021e71d5c4ecd15ef8bf1979ai0", 
+    "meta": { "name": "Derage #1" } 
+  },
+  {
+    "id": "0ddc35dafa93cbc7e2cddfc5ba81ae57d159703eafcd39f5390f139b7cc24abei0", 
+    "meta": { "name": "Derage #2" } 
+  },
+  {
+    "id": "6b0a29468645fb6f9f5de44ffc354dc7d058e0611cbef1e0f01bc1062a3c6b30i0", 
+    "meta": { "name": "Derage #3" } 
+  },
+  {
+    "id": "32b0257fd79ec827e8826939c8a04a17f214769bf66d75342294acb3cead45e1i0", 
+    "meta": { "name": "Derage #4" } 
+  },
+  {
+    "id": "cb9dc764382b823459e1aff6e4a8e29bda314d71608f7cc494e774befa2f03eci0", 
+    "meta": { "name": "Derage #5" } 
+  },
+  {
+    "id": "ef137a87e457e2ba54f090fbee300d92decbd90567d351f5b5e15bc67cb8fbc7i0", 
+    "meta": { "name": "Derage #6" } 
+  },
+  {
+    "id": "c042c1182dfb8d884229140e35d405f154395e87ee53e596664ab5e6ccbaf605i0", 
+    "meta": { "name": "Derage #7" } 
+  },
+  {
+    "id": "5cecbad09f7df8b5a4f5b298dfe91e32094275960d2e8fffb6c3ad1e99def737i0", 
+    "meta": { "name": "Derage #8" } 
+  },
+  {
+    "id": "5f5b828490c534e39920f9196c6f1fdbe1bcb272fd7efade3fee1505b767befdi0", 
+    "meta": { "name": "Derage #9" } 
+  },
+  {
+    "id": "e9e38342a8a25d997b396368910d7595ba8757d53a25d321b04a87511ef6f882i0", 
+    "meta": { "name": "Derage #10" } 
+  },
+  {
+    "id": "76625761deb9925420e9ca1d4cb4356aca0d8807dc92ed350303984a6ffcc992i0", 
+    "meta": { "name": "Derage #11" } 
+  },
+  {
+    "id": "31b4057aad120722e42419b4166c9e7eafb80933650661a24ae95f2100b657d7i0", 
+    "meta": { "name": "Derage #12" } 
+  },
+  {
+    "id": "47727ffee6bc15593e318755a49fb481025c6c7028427b71225cbcb21ccbbcf3i0", 
+    "meta": { "name": "Derage #13" } 
+  },
+  {
+    "id": "b4ddb4e48e82bf5f1ef5845bf23b22f560359a33ef102d72c1f5d7ef308372e1i0", 
+    "meta": { "name": "Derage #14" } 
+  },
+  {
+    "id": "7cdc0d79f8ff3ec742fd1fa7ff6d474134f3a2837b71c9f7e1523f78e20d5002i0", 
+    "meta": { "name": "Derage #15" } 
+  },
+  {
+    "id": "84b24cacb21f2f25ff64f550d12c44acbb683f5308f87aaeb1259d3fe94ba184i0", 
+    "meta": { "name": "Derage #16" } 
+  },
+  {
+    "id": "48b2c1bf110b8eb42dd597758efd54f94cc4beac0687907fc14588fdd89cb083i0", 
+    "meta": { "name": "Derage #17" } 
+  },
+  {
+    "id": "d9a1f3af2144fc976de04a818ff2c3f73e766b4312a34828b305144cfddeada6i0", 
+    "meta": { "name": "Derage #18" } 
+  },
+  {
+    "id": "abbdc4643714b80413b54983572d728484ffba8f14d7c2d636d76a3b31e09c96i0", 
+    "meta": { "name": "Derage #19" } 
+  },
+  {
+    "id": "00b668a69235389957f2056570aaaba1942d3e134deaea5f0c1a0cdd219455e7i0", 
+    "meta": { "name": "Derage #20" } 
+  },
+  {
+    "id": "9c36cd9b47767da245260971e4c1bf1ed0cb0db96a21100d962cdd67003f065fi0", 
+    "meta": { "name": "Derage #21" } 
+  },
+  {
+    "id": "0e1f9966330c12378de49a294da85e51f357fea52699629076bceaa5a26c684bi0", 
+    "meta": { "name": "Derage #22" } 
+  },
+  {
+    "id": "1efba544121505b654ab14dcc2abaf38aac137de1fba8664ba22612dcd621888i0", 
+    "meta": { "name": "Derage #23" } 
+  },
+  {
+    "id": "c07b3398edf59ff78030e4afa4dba79e32c660d0f971527a1b5014c7af679712i0", 
+    "meta": { "name": "Derage #24" } 
+  },
+  {
+    "id": "9564680ed4afcd36af32988e6687fa17fee92fb5becadaecbab41f80da6e4eb9i0", 
+    "meta": { "name": "Derage #25" } 
+  },
+  {
+    "id": "5d943b922516bcde5e35ad7502160095e0fb7fce8ee8d00d669811d1604bd4b8i0", 
+    "meta": { "name": "Derage #26" } 
+  },
+  {
+    "id": "549ae97155d16f790b86cc35ab8e3e010cf3c6b776d3e27ab7fc913750647ad1i0", 
+    "meta": { "name": "Derage #27" } 
+  },
+  {
+    "id": "8d4413c4d5627639bf27a3b17521908ab659b4cb4c94e7c8439504849f165e02i0", 
+    "meta": { "name": "Derage #28" } 
+  },
+  {
+    "id": "1aeec63ffd3516500284f7b5b55581bfbace10b34c0be41d2c84e6494a77355ci0", 
+    "meta": { "name": "Derage #29" } 
+  },
+  {
+    "id": "e7439b59bdf935d4020150093d034bacb4605443d38f25f416e0be706bd32fd7i0", 
+    "meta": { "name": "Derage #30" } 
+  },
+  {
+    "id": "8691ea2ae9d2a87e9e444f9ffa16115397fbb124f47a8ecb0a6b5a93d5cb109ei0", 
+    "meta": { "name": "Derage #31" } 
+  },
+  {
+    "id": "9e27b23abc24a1b7a2682ebd3530538abe4388c1f41a3da196d977d6ac7b933fi0", 
+    "meta": { "name": "Derage #32" } 
+  },
+  {
+    "id": "a75548884d72d40864eccd6046cfe41807040997e3aad2bd594602f9bd49914di0", 
+    "meta": { "name": "Derage #33" } 
+  },
+  {
+    "id": "0d40e925978aabe2331f625af695a4ed21710f0c44bb820f18df13ac3f97ee09i0", 
+    "meta": { "name": "Derage #34" } 
+  },
+  {
+    "id": "d4f8fefcefa7dac19ac4fbc5d6b19d5f4fd2f76465dbacddc3dad791f1b82e54i0", 
+    "meta": { "name": "Derage #35" } 
+  },
+  {
+    "id": "2897353223683cb8d5b27e2cbfb245bac5a523284fa808c11e082136d54978c2i0", 
+    "meta": { "name": "Derage #36" } 
+  },
+  {
+    "id": "73a07680f51f5e8c576b18ff5fae6517245c1240af937a06f56992a64f4d44b5i0", 
+    "meta": { "name": "Derage #37" } 
+  },
+  {
+    "id": "502a991a92811bc4b6bdafddb57e1343befa113e23e8227dabcc2335b50a9c12i0", 
+    "meta": { "name": "Derage #38" } 
+  },
+  {
+    "id": "c59108cd178e2f5ccc6dec8a78b935b4ba4f7e7bc1ca24ac79b388708b136c9ci0", 
+    "meta": { "name": "Derage #39" } 
+  },
+  {
+    "id": "4a58861cdaada7ae0b84175ac0c047988e91b6cd2f63fe8b503c4a0900a9ad1ei0", 
+    "meta": { "name": "Derage #40" } 
+  },
+  {
+    "id": "d4c9443ca645b3f58a2dbcdbc0e9ffdb2373ea33789167eacf508df143e96445i0", 
+    "meta": { "name": "Derage #41" } 
+  },
+  {
+    "id": "7410f521ed033e748c613143063f2bac2d750b518f8a0a96d2981565bed4598fi0", 
+    "meta": { "name": "Derage #42" } 
+  },
+  {
+    "id": "fe8efe7bb0e8d1a74540904a0e28f544011aaf3ca4e9d83e48f16d55cf0e5a7ai0", 
+    "meta": { "name": "Derage #43" } 
+  },
+  {
+    "id": "0d73ea6de24b6d4fd68f56d6a9d2d51a044d99b6db9fdd90f642cf31b8994ae0i0", 
+    "meta": { "name": "Derage #44" } 
+  },
+  {
+    "id": "08e331203c443a0ad9a3069fba44bda4b1bc5b1504bc339b2af7b84a8e316c76i0", 
+    "meta": { "name": "Derage #45" } 
+  },
+  {
+    "id": "5990095b438c8c39dbc0c535b317e3c5e7a1decfbae624cb63354c152fe989bdi0", 
+    "meta": { "name": "Derage #46" } 
+  },
+  {
+    "id": "4ad8f0324d4a68ef3b633f1e2660300bdb58ccc54b836ca89346e9f0589069a0i0", 
+    "meta": { "name": "Derage #47" } 
+  },
+  {
+    "id": "0c4942e77a68ebb281b229527f65191b50e21404675da5abae436951532f03f7i0", 
+    "meta": { "name": "Derage #48" } 
+  },
+  {
+    "id": "8b49caf1ea1e74ccda38fb8c5ac12015381e2a8323bc79221ff929dbe85b4a8fi0", 
+    "meta": { "name": "Derage #49" } 
+  },
+  {
+    "id": "32348e3c5561c1046dad7e3f30ea5f12b924bb140cbb2dc92e2a658653fe2686i0", 
+    "meta": { "name": "Derage #50" } 
+  },
+  {
+    "id": "0969d34ae7ea16c23901eb5d9ca0475f910510d67ac460578421559a4026381ai0", 
+    "meta": { "name": "Derage #51" } 
+  },
+  {
+    "id": "0e67b5effb0d137021bd90ead4a0864f5a150bb925a638ed7ceaf28a3289c755i0", 
+    "meta": { "name": "Derage #52" } 
+  },
+  {
+    "id": "f8c3737f80b04108116a01286a4488a3711a39c6a01cdaabb3196a598389a88ei0", 
+    "meta": { "name": "Derage #53" } 
+  },
+  {
+    "id": "a3828cdcde37b5ab8360fddadb8c94bb8b06d555b8ac8bf237777aa4c9dac307i0", 
+    "meta": { "name": "Derage #54" } 
+  },
+  {
+    "id": "fc1f8023cbff820220404f6b31738cf98684311c701f94cf13b214f054a53052i0", 
+    "meta": { "name": "Derage #55" } 
+  },
+  {
+    "id": "e36ac4655f2c6817bede7bfc26a0ffe3b7eb26f160a3f99dbaac720eae19e8e9i0", 
+    "meta": { "name": "Derage #56" } 
+  },
+  {
+    "id": "f7d35a929be7879bc37256fce75bee214f849314ea28d44ce8d406da28aa56e2i0", 
+    "meta": { "name": "Derage #57" } 
+  },
+  {
+    "id": "02f63aec5c45b905eb61dbf4cef4e262f75e12b9e4f62e20e872198cb2a3263bi0", 
+    "meta": { "name": "Derage #58" } 
+  },
+  {
+    "id": "78563702aae741392adbac12c892fd1737403f78b49a4dba3bb6f38f3283b47di0", 
+    "meta": { "name": "Derage #59" } 
+  },
+  {
+    "id": "45d51bf2fa4a6892209f2051a8993617b884619dd629b7f84d6708829d146a01i0", 
+    "meta": { "name": "Derage #60" } 
+  },
+  {
+    "id": "0262b0e771bae5a07103504218a64d38e06ad1ab693603bbe6259548ef0f6b7bi0", 
+    "meta": { "name": "Derage #61" } 
+  },
+  {
+    "id": "77c381a9d93e757c233795da39035be11ef5cfd727acc69b394993b528742ae1i0", 
+    "meta": { "name": "Derage #62" } 
+  },
+  {
+    "id": "ef39effde59d199509b798bbe2077ead7da128c134d5ebb4b7619ea7d0888ff4i0", 
+    "meta": { "name": "Derage #63" } 
+  },
+  {
+    "id": "1be3eca328a0a5e5788fa38c611d593003aebbb0b645e6d55cb65526a68304b1i0", 
+    "meta": { "name": "Derage #64" } 
+  },
+  {
+    "id": "6184eddccd911b4df7aa951abad4333340a97b5c8ad20994aef2f8067c061cb5i0", 
+    "meta": { "name": "Derage #65" } 
+  },
+  {
+    "id": "cfc177d2cbc41eb478aa47747f184d57c78cee1d0821a7b5be4a0369f057ec87i0", 
+    "meta": { "name": "Derage #66" } 
+  },
+  {
+    "id": "fc203bb5dba964176d704f8b400cbf81ff01ac50e42f446e49d6f63b72b07ab1i0", 
+    "meta": { "name": "Derage #67" } 
+  },
+  {
+    "id": "977995788d8d3f6ae0af6669758325eb53165ee87e64018ab525e9f3b614d14ci0", 
+    "meta": { "name": "Derage #68" } 
+  },
+  {
+    "id": "5a77396bbfad72ab48eb15e5091e9f02e893ce8c2369c9f73a9e9ae8b5dc0898i0", 
+    "meta": { "name": "Derage #69" } 
+  },
+  {
+    "id": "2e5d930a65dbd79fcea45b699986c0a723206bc3e7b6d166cc60c23d87988e51i0", 
+    "meta": { "name": "Derage #70" } 
+  },
+  {
+    "id": "4abc2b0c9456cc4ebc54578ec142d033a2bfc8b17ed89ac8bfdba2189d7d49a4i0", 
+    "meta": { "name": "Derage #71" } 
+  },
+  {
+    "id": "7e93612f9cd8b2596c8e8392b2ae562c252e32a5979b4ec3d0ac4029f894bfabi0", 
+    "meta": { "name": "Derage #72" } 
+  },
+  {
+    "id": "1f0d7e073091c08bd5ce45e076f6749374e6217c13fa75a6e00a29ccaba3c7b6i0", 
+    "meta": { "name": "Derage #73" } 
+  },
+  {
+    "id": "d330e13c31daed33b136457a7516e2184c035bfeead4e814e485ff4eb4473324i0", 
+    "meta": { "name": "Derage #74" } 
+  },
+  {
+    "id": "8620a62219fb7a2f317a51c33169eed1eabccd5addea5fc8cf165bdb7951c8afi0", 
+    "meta": { "name": "Derage #75" } 
+  },
+  {
+    "id": "6b9e0ba33868f06f3fbaf7c707bf9cfa0e390a5548be04782be983fb1418c2f4i0", 
+    "meta": { "name": "Derage #76" } 
+  },
+  {
+    "id": "88a980419beb2d260e95be9fb6d5ea220b73ec7dc97d74bed83c323b140d5cbai0", 
+    "meta": { "name": "Derage #77" } 
+  },
+  {
+    "id": "de0c1ed7b9c526edd7069701337b3c225d1544807ff79501f2ee86108e411fb1i0", 
+    "meta": { "name": "Derage #78" } 
+  },
+  {
+    "id": "519bef447de4779d7c2bc767740e99072d5389acfd8ff72be4cf6b1cc9223aadi0", 
+    "meta": { "name": "Derage #79" } 
+  },
+  {
+    "id": "2632b255fd64db58997e32fef27d5b086afe4a578788869cc835a0370f2ee3bdi0", 
+    "meta": { "name": "Derage #80" } 
+  },
+  {
+    "id": "7cfb5187ea08519471fdcbb4b6a325dafdc14234c8697538a7d11d120be34711i0", 
+    "meta": { "name": "Derage #81" } 
+  },
+  {
+    "id": "9676f64ac82967acaeea3c3b07acfd4865ebb23a3dd270d15dfc4399dfb4f4dci0", 
+    "meta": { "name": "Derage #82" } 
+  },
+  {
+    "id": "389947db475b3eabffa1396073b522095842ac3842c07a340a66f3059c3c5264i0", 
+    "meta": { "name": "Derage #83" } 
+  },
+  {
+    "id": "93a8f5bb6cdda630bd4f1bdc8aab7d41ad679279c69f40694c100f78105c68ffi0", 
+    "meta": { "name": "Derage #84" } 
+  },
+  {
+    "id": "b9528874bc5d8b0d25a41c6f3395b72794356c02086c1357e8e3da6f3f2ffb89i0", 
+    "meta": { "name": "Derage #85" } 
+  },
+  {
+    "id": "41127eceb8a5f14895100f8364b60036e37d1d271bff65c435859033b306a581i0", 
+    "meta": { "name": "Derage #86" } 
+  },
+  {
+    "id": "47b7f19d1615a76e2877851393f3fb1d81ee1377e05a3b66f4b206bb8684a9d9i0", 
+    "meta": { "name": "Derage #87" } 
+  },
+  {
+    "id": "b81c119641a3ace5283cc3e5638591568706a3fcdc5d98ddcc828f64d3a68d88i0", 
+    "meta": { "name": "Derage #88" } 
+  },
+  {
+    "id": "090c57805d32f439b70ebbac6c12675b22ffbec0f0e151d47b56b1a55c1e00c1i0", 
+    "meta": { "name": "Derage #89" } 
+  },
+  {
+    "id": "c354fc8c45b0652f94190a79c23e21bc3de26005c21696d5df0ccd8610e791c4i0", 
+    "meta": { "name": "Derage #90" } 
+  },
+  {
+    "id": "fc2acbf2717f7a7108041cf09e05065cd8b9f94655d3b84699c482cb0cc3e7e9i0", 
+    "meta": { "name": "Derage #91" } 
+  },
+  {
+    "id": "cbd57c016526dfded1a52be59e41cc56e2b36f59a00166dada9b5ca3fec5fb33i0", 
+    "meta": { "name": "Derage #92" } 
+  },
+  {
+    "id": "e15b0102bc63efe43842a387bcde0feaf400521b72a5c8134026377121467fafi0", 
+    "meta": { "name": "Derage #93" } 
+  },
+  {
+    "id": "16ad7bfb77e27b54f7321c7f80d6d4b48b39530abef367dad188183bfddfe274i0", 
+    "meta": { "name": "Derage #94" } 
+  },
+  {
+    "id": "7eba1e5bf5291b4da4a8ec678e96604f189183347f159d50077d7b545c8071c4i0", 
+    "meta": { "name": "Derage #95" } 
+  },
+  {
+    "id": "7430f52e4706d9ea69a522125fca9095b7a781f32e9096cc12aaf02245ba34a1i0", 
+    "meta": { "name": "Derage #96" } 
+  },
+  {
+    "id": "ab8647df4f58002375ec3dcd410b01235146e95ad5ad2784bb9cc005c0fc774bi0", 
+    "meta": { "name": "Derage #97" } 
+  },
+  {
+    "id": "3ce9cb700ee014c0feb24bac3a640f370916e792f6780fad7be3d417e7a367e6i0", 
+    "meta": { "name": "Derage #98" } 
+  },
+  {
+    "id": "d299a766178ad719750fca35f9cd08940ecbeb1318bbc5ba2c7e3aefb0542234i0", 
+    "meta": { "name": "Derage #99" } 
+  },
+  {
+    "id": "e19cac165c0ded27ae1791319cc4c47162218a68510a6dd347373f185cd9edebi0", 
+    "meta": { "name": "Derage #100" } 
+  },
+  {
+    "id": "a95717837fa373517f3f0f4742b20548d69c2e27274037d8979ffff45d98fe81i0", 
+    "meta": { "name": "Derage #101" } 
+  },
+  {
+    "id": "e7a3a83539bbec8c88b0922eb3b5f6b15279e107dc30b6c73a95da99f42e3334i0", 
+    "meta": { "name": "Derage #102" } 
+  },
+  {
+    "id": "1c5df360bcbf04d78c918e6f4b1f6e328b3519d09b37e1761592086780fd330ei0", 
+    "meta": { "name": "Derage #103" } 
+  },
+  {
+    "id": "da10484fe2405550dd296e56f053c5e6649c094b0ab625f87970a0b44733c919i0", 
+    "meta": { "name": "Derage #104" } 
+  },
+  {
+    "id": "9dff6ebe0481db3f9fdc769f38bce72869feaffb6e97d9106f57fb5ce07a75d9i0", 
+    "meta": { "name": "Derage #105" } 
+  },
+  {
+    "id": "f086989138843807aab673c117236e2b3798ea87efbbbc8a656bae104aa4aa3bi0", 
+    "meta": { "name": "Derage #106" } 
+  },
+  {
+    "id": "9a259f87f18b090aab1ab87011f99a1a24cf79033c714acc94208a52931abb5fi0", 
+    "meta": { "name": "Derage #107" } 
+  },
+  {
+    "id": "70ac3dbbea84cad1c19c03f1f574a6625d74507a8768c5ab84fe010fbe218b92i0", 
+    "meta": { "name": "Derage #108" } 
+  },
+  {
+    "id": "12248f708a35f84d87059ec260ee20c8b9425c4b447627fa7f5ec73ca3db76eci0", 
+    "meta": { "name": "Derage #109" } 
+  },
+  {
+    "id": "a88b0f5416741ad90281d503d32afd50b89853f340c0e8f902ddc7878a4304fbi0", 
+    "meta": { "name": "Derage #110" } 
+  },
+  {
+    "id": "9a759f929bcb13fd30f1f95ed46b154a9b4d9a34c2decce2fd1d51b4aa2e674fi0", 
+    "meta": { "name": "Derage #111" } 
+  },
+  {
+    "id": "ea66aef7bd337a3e156c0494868cb4a526e5f81973fd95bc09bbfd107428f4ebi0", 
+    "meta": { "name": "Derage #112" } 
+  },
+  {
+    "id": "5dd9c4d96a859fb1dba068317adcdcb67f9d485880285e2af5a4e703b0c258dbi0", 
+    "meta": { "name": "Derage #113" } 
+  },
+  {
+    "id": "103097db1023b6deaa418ab0ec108f42a872e015d441da67920fdbe39c04e06ei0", 
+    "meta": { "name": "Derage #114" } 
+  },
+  {
+    "id": "d1425d24c81d34ff438d8550f7dad2f67bbeab734bd5dba7a399dc1a59c5738di0", 
+    "meta": { "name": "Derage #115" } 
+  },
+  {
+    "id": "8a133ef3518aca49dbeec557b1fb78a5169e8bdd96927ac9f6864020ebb68040i0", 
+    "meta": { "name": "Derage #116" } 
+  },
+  {
+    "id": "d2474bb80873232c9f9c639f1dc56bde99ec4e764e55ff1c645a98518edf4db8i0", 
+    "meta": { "name": "Derage #117" } 
+  },
+  {
+    "id": "ddc5c956d3b5159f66fb6c6d7a243a4cb4d6399bd5a863390de256c137d8f475i0", 
+    "meta": { "name": "Derage #118" } 
+  },
+  {
+    "id": "758be59584c478a0912e2f2fbf98b141474ab321a7856a4f3693fc58cc78c59fi0", 
+    "meta": { "name": "Derage #119" } 
+  },
+  {
+    "id": "2163ec4119ffd115e2abfbc3e201ae4e6d46f72af3bcf20800af72ba123d8225i0", 
+    "meta": { "name": "Derage #120" } 
+  },
+  {
+    "id": "895c5c078717ed203140fdad4497fd7221a8c2d55e94a926928f11014577e892i0", 
+    "meta": { "name": "Derage #121" } 
+  },
+  {
+    "id": "3912a512f4eeb87415797c8cbb7f7c83d69dd3cdddf74ee2212af594e066030ei0", 
+    "meta": { "name": "Derage #122" } 
+  },
+  {
+    "id": "7441e94c9f6f4e5f5f0398e41deff9d9e69dc8b2e51798a387b1ec255813a6b6i0", 
+    "meta": { "name": "Derage #123" } 
+  },
+  {
+    "id": "a7793e2277997c77d20bfee6249a888f57744ea01bf495438b0ed461e83fc6c9i0", 
+    "meta": { "name": "Derage #124" } 
+  },
+  {
+    "id": "43447ee6412b0c0bc959e9e097f3fb0d1aed7fd49952477752a28670bcfc80aei0", 
+    "meta": { "name": "Derage #125" } 
+  },
+  {
+    "id": "dc5687ba1ef75180860eef8d978c309b4dc62d1e59f6f3e3180ee2851222ff4ei0", 
+    "meta": { "name": "Derage #126" } 
+  },
+  {
+    "id": "48f1b671ef78d552b42b8fdb4182a8119483fe66b9db5d3c4d22f592357b5118i0", 
+    "meta": { "name": "Derage #127" } 
+  },
+  {
+    "id": "8a5cb46fe048de6dfd46e3fca015edba2e985d30cbd92f0ed41c05c9929af6afi0", 
+    "meta": { "name": "Derage #128" } 
+  },
+  {
+    "id": "c070c442cac7dce87609533bbd67d864d066aef7fefd31d2d690cd82ef59afbai0", 
+    "meta": { "name": "Derage #129" } 
+  },
+  {
+    "id": "40acbe7abf61709042a9616cc2bd2eee177871f63f2fb50c80571cd041135dadi0", 
+    "meta": { "name": "Derage #130" } 
+  },
+  {
+    "id": "124dfc58426141a231d98bc7f62a300fae02bae8fc4502478a1e912621123f33i0", 
+    "meta": { "name": "Derage #131" } 
+  }
+]

--- a/collections/derage-darkfarms1/meta.json
+++ b/collections/derage-darkfarms1/meta.json
@@ -6,5 +6,5 @@
   "description": "A 4201 Derivate Degen Rage collection by Darkfarms1. CC0",
   "twitter_link": "https://twitter.com/Darkfarms1",
   "discord_link": "https://discord.gg/XzvGhuqxzv",
-  "website_link": "derage.eth"
+  "website_link": "https://derage.eth"
 }

--- a/collections/derage-darkfarms1/meta.json
+++ b/collections/derage-darkfarms1/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "Derage by Darkfarms1",
+  "inscription_icon": "5cecbad09f7df8b5a4f5b298dfe91e32094275960d2e8fffb6c3ad1e99def737i0",
+  "supply": "132",
+  "slug": "derage",
+  "description": "A 4201 Derivate Degen Rage collection by Darkfarms1. CC0",
+  "twitter_link": "https://twitter.com/Darkfarms1",
+  "discord_link": "https://discord.gg/XzvGhuqxzv",
+  "website_link": "derage.eth"
+}

--- a/collections/derage-darkfarms1/meta.json
+++ b/collections/derage-darkfarms1/meta.json
@@ -2,7 +2,7 @@
   "name": "Derage by Darkfarms1",
   "inscription_icon": "5cecbad09f7df8b5a4f5b298dfe91e32094275960d2e8fffb6c3ad1e99def737i0",
   "supply": "132",
-  "slug": "derage",
+  "slug": "derage-darkfarms1",
   "description": "A 4201 Derivate Degen Rage collection by Darkfarms1. CC0",
   "twitter_link": "https://twitter.com/Darkfarms1",
   "discord_link": "https://discord.gg/XzvGhuqxzv",


### PR DESCRIPTION
The following files add collection data for the Derage collection. The CC0 project by art producer / doodle master Darkfarms1 burnt a big chunk of its supply on Ethereum to be on a proper chain now. We used the meta name property to link the burnt asset on Ethereum to the ordinals inscription.

Original collection for reference:
https://opensea.io/collection/derage