### PR TITLE
Update inscriptions.json

### DIFF
--- a/collections/bitcoindigits/inscriptions.json
+++ b/collections/bitcoindigits/inscriptions.json
@@ -90,7 +90,7 @@
     }
   },
   {
-     "id": "7fb57a68183b036770b12912a8e6b5f8ab260af0a3daff7dc5866c4884cf8539i0",
+     "id": "4758a0a0a7b8bec66a65df3676a7e7e74be2580ae8744e28bb86aca2b1cb2e0fi0",
     "meta": {
       "name": "Bitcoin Digits #4",
       "status": "Mythic",
@@ -275,7 +275,7 @@
     }
   },
   {
-   "id": "f088010a9fafeff69c59145d5cb17f20ceb58a62cba7d419ca93823bf05114b1i0",
+   "id": "ff1d9c74b53cd99c9ef6f459c9cee733e647ba3141b66ed844d319417637f53ci0",
     "meta": {
       "name": "Bitcoin Digits #14",
       "status": "Mythic",
@@ -290,7 +290,7 @@
     }
   },
   {
-   "id": "239e7fe190525c9514bad6e86e93570f36b5f990a6cb197344538289a4a74318i0",
+   "id": "4973d55b67690fdfc4f156fd53d325c4b9e215294a35cfebe5a5e305b2298cbci0",
     "meta": {
       "name": "Bitcoin Digits #15",
       "status": "Mythic",
@@ -305,7 +305,7 @@
     }
   },
   {
-   "id": "c2b1e41be0a5eb6f50a75a01e4bcff42b76e358b4567718aa07238d5fb526cd7i0",
+   "id": "ddce64eb84c9b70f2bbe862b77ec817e4c5af45e73f1352b96bb8c691414bb95i0",
     "meta": {
       "name": "Bitcoin Digits #16",
       "status": "Mythic",
@@ -340,7 +340,7 @@
     }
   },
   {
-    "id": "7166e464d72c1046f5662d1a6058f2c00fc31939c4eeb33fbc86bf80feaefb29i0",
+    "id": "6698b3694d129745488e56ef930d7174a2dbdcdacfa1653c8a98e0238e44e3a8i0",
     "meta": {
       "name": "Bitcoin Digits #18",
       "status": "Mythic",
@@ -410,7 +410,7 @@
     }
   },
   {
-   "id": "83f8718c8d6877ad8ece3a68f89c5a2caf48179a3bb57cb057e4ffe7f12bad2ai0",
+   "id": "30de69f5a93f631792e75ae017c812851cc21ad1ad9b4f8102614f91dbbb3f20i0",
     "meta": {
       "name": "Bitcoin Digits #22",
       "status": "Mythic",
@@ -445,7 +445,7 @@
     }
   },
   {
-   "id": "21ee95f5dcec40ef2b29e5ae9d20d08db67ca993bc91fd595568ff89e67dec22i0",
+   "id": "649f08068d49340f81590f19c98bf67dd9ac0b8c5f6903af05bd395563e82e56i0",
     "meta": {
       "name": "Bitcoin Digits #24",
       "status": "Mythic",
@@ -475,7 +475,7 @@
     }
   },
   {
-   "id": "14a53d176a68ce6e3d2d2fb28ebef61eee6ccb36a9dddaadee402775b13dc9e7i0",
+   "id": "f73500b2f3fbe4c3fcd0d8c755cabc883f334d3c8c4acf94997f2e2c42134cfei0",
     "meta": {
       "name": "Bitcoin Digits #26",
       "status": "Mythic",
@@ -490,7 +490,7 @@
     }
   },
   {
-   "id": "dbe813ff970a7bb1c76529a42154aad4a5bee7e4e8c6f1348017517a8f419d7ci0",
+   "id": "269d885d6d54d910574cc64534c52d87ab0a100394e6ecf28ddb706e0ee35e68i0",
     "meta": {
       "name": "Bitcoin Digits #27",
       "status": "Mythic",
@@ -505,7 +505,7 @@
     }
   },
   {
-   "id": "d81eea0e4d3dbf3dcaebe88d5603adf56e7bcbf0b95899ef01fdb41d6a207780i0",
+   "id": "a98cb15121711b11390650493deddde593bfa376e5330b7e283ccfed2b1b9643i0",
     "meta": {
       "name": "Bitcoin Digits #28",
       "status": "Mythic",
@@ -520,7 +520,7 @@
     }
   },
   {
-   "id": "52ebd053706180ed1f084de747ee2241d77b86207eb2de2a777a21eac7bb0704i0",
+   "id": "963aacb3827335630bdda893d70d3e8d16633221c8d29c741aeab51d09c77c45i0",
     "meta": {
       "name": "Bitcoin Digits #29",
       "status": "Mythic",
@@ -540,7 +540,7 @@
     }
   },
   {
-  "id": "8de6f3288f028c593aa5473e3bff2d4bf4d0a3f7f3f5d07ee2d0d109388b677di0",
+  "id": "bfa4e63f9fd5a3b5b790aa60c1c6fe33fc17cb2e85c10ca4bb62de43b469dd39i0",
     "meta": {
       "name": "Bitcoin Digits #30",
       "status": "Mythic",
@@ -555,7 +555,7 @@
     }
   },
   {
-   "id": "92a9ac8bd1584954f7370b9c961109719982e6b569dc20dd768851a958189452i0",
+   "id": "e4d6842fea7e7a10fa0cd67c251136f9dfe7a6116178115f5832ed2df422b4b1i0",
     "meta": {
       "name": "Bitcoin Digits #31",
       "status": "Mythic",
@@ -590,7 +590,7 @@
     }
   },
   {
-   "id": "8c0298c6ddd3275ea3d4477a5971e89c60411c312dd80077c56a88c5fa477890i0",
+   "id": "11fc2c73a309a4eebea86f2b0b8bca09f0c8fd20f134aab8b269ba04d1bfd4bbi0",
     "meta": {
       "name": "Bitcoin Digits #33",
       "status": "Mythic",
@@ -625,7 +625,7 @@
     }
   },
   {
-   "id": "ae746fb328f85f87d7138b3aae9d18f5f4929432449b0e00aaaaaea1373ac392i0",
+   "id": "53d610a723c261dd9318017d6fddeace9260514445c1c489558f7b43dbd89092i0",
     "meta": {
       "name": "Bitcoin Digits #35",
       "status": "Mythic",
@@ -640,7 +640,7 @@
     }
   },
   {
-   "id": "21e2683bb6e532b05a2603d04979ae874a8c7ac32c9ed49cdc97e5a91fb77c43i0",
+   "id": "99925628f69264feeb521a99bdd5a96c80a3c52eaf2dfe206a3ab31fb91a864ai0",
     "meta": {
       "name": "Bitcoin Digits #36",
       "status": "Mythic",
@@ -655,7 +655,7 @@
     }
   },
   {
-   "id": "c691d17533d00b54e51ff0ce3dba02bc1fe1b4d49d1a1eeed62cfa8f9ea4d9c7i0",
+   "id": "18d25f4a58047b0e97dcbb162581adc2ad01de688c70954e4898bb050d668044i0",
     "meta": {
       "name": "Bitcoin Digits #37",
       "status": "Mythic",
@@ -675,7 +675,7 @@
     }
   },
   {
-   "id": "a155f0447fbdbb33dcb47e7092984fb24aefc81cef18f009dde56884570a24adi0",
+   "id": "09b8cfbfc1c865a81e550e76bf877006864bd0bed27bf2363757b07e6e4f4feai0",
     "meta": {
       "name": "Bitcoin Digits #38",
       "status": "Mythic",
@@ -690,7 +690,7 @@
     }
   },
   {
-   "id": "3eaa5fa09bf76c10dfdb1c098af6ddf6ae172e970be54f5d12e5861168db2408i0",
+   "id": "3174f3f0715481aa3df6817a4268a801ccdd103523b24552cffe03d02681b2d9i0",
     "meta": {
       "name": "Bitcoin Digits #39",
       "status": "Mythic",
@@ -705,7 +705,7 @@
     }
   },
   {
-   "id": "8821e86e354b748ef25a8c88d28d82039183f117b0438996020d6f6b977d57bci0",
+   "id": "f08c7ee0f34f410654ae662df3f33ec4fe1f1485aeb0d5437edf8bd21d9c3b08i0",
     "meta": {
       "name": "Bitcoin Digits #40",
       "status": "Mythic",
@@ -720,7 +720,7 @@
     }
   },
   {
-   "id": "b8640cac93f5f1a15739fe63e1142348e741a5b1ba91feb1dddb2a0234c020c6i0",
+   "id": "446395f2e0b79099b01d94a1e9b7e8ce7376e4fec1b502adc9873977645f5772i0",
     "meta": {
       "name": "Bitcoin Digits #41",
       "status": "Mythic",
@@ -755,7 +755,7 @@
     }
   },
   {
-   "id": "0123b628c29c523dfc6ff5e7927e72a315e379644cee75cec1a3e1878f79afc3i0",
+   "id": "6f0faeba67f70d823764ba1c78de97e1b0dbc86854c8b3b933f1900583f91a56i0",
     "meta": {
       "name": "Bitcoin Digits #43",
       "status": "Mythic",
@@ -790,7 +790,7 @@
     }
   },
   {
-   "id": "31f6b66cdac2d5696155ff97993916013eab3dbe8d91b96439c936fac2a5aaf3i0",
+   "id": "8664992fa184cdc7239e53406210e4eb8e6af84ac438844b8035ea7f4e694407i0",
     "meta": {
       "name": "Bitcoin Digits #45",
       "status": "Mythic",
@@ -805,7 +805,7 @@
     }
   },
   {
-   "id": "fb991271543ebf2c967961d08f04bb65f9eacdbbbcac5e70e27ce0d6f9a50d7bi0",
+   "id": "2920fe85166fd9248f2888ccfaa3c3aee7cccb745f4c678fb9ba535dc67cd480i0",
     "meta": {
       "name": "Bitcoin Digits #46",
       "status": "Mythic",
@@ -820,7 +820,7 @@
     }
   },
   {
-   "id": "1437212c0809a0f4a26ec3969f00458f854ba2428cf52fc2a60456ed50d04b05i0",
+   "id": "687a919878b9414fa318df98e4957d8d722baa467d3a2df136792abc033dee1ai0",
     "meta": {
       "name": "Bitcoin Digits #47",
       "status": "Mythic",
@@ -840,7 +840,7 @@
     }
   },
   {
-   "id": "d58363027b59cab049096825b58796f0730cc6cf058cd0f7c0573c1faa29a17bi0",
+   "id": "9325e1ecb03579dc52145e4fb7260a2bd8e8009b17e1470c0aa0b3f86005aecbi0",
     "meta": {
       "name": "Bitcoin Digits #48",
       "status": "Mythic",
@@ -855,7 +855,7 @@
     }
   },
   {
-   "id": "9e0a06114754aa538b8509eed84b9f8f063055905132144a5a36fd87e1631104i0",
+   "id": "2e2ed01f642bb05da7dd0349660804b7f80904e01e62ae2301053bc041683ef5i0",
     "meta": {
       "name": "Bitcoin Digits #49",
       "status": "Mythic",
@@ -870,7 +870,7 @@
     }
   },
   {
-   "id": "b686e3df060caa9b08ca928e2afc7e1539276e213630b7b4ebcaab8210b947fai0",
+   "id": "398c0f4a758cde35a7c081abf0070c3c6a865d17cb8a8b98177689c8e6846c5ai0",
     "meta": {
       "name": "Bitcoin Digits #50",
       "status": "Mythic",
@@ -885,7 +885,7 @@
     }
   },
   {
-   "id": "c7416816b32aad387f23343c572d301f8625ad373418f6c81d1660c70482b2d7i0",
+   "id": "95a010331883c977817aab69dbf09191daae1831e169725644a68dfb3e95b0fai0",
     "meta": {
       "name": "Bitcoin Digits #51",
       "status": "Mythic",
@@ -900,7 +900,7 @@
     }
   },
   {
-   "id": "e71c47e26db17e4e5b969b65ccddd29f9de0592460591d3c3ef4386cb4f2e16ai0",
+   "id": "793354508fab2ae391fc042e51a84576666ddcd5d2c5219f3f277b776e94cfa2i0",
     "meta": {
       "name": "Bitcoin Digits #52",
       "status": "Mythic",
@@ -915,7 +915,7 @@
     }
   },
   {
-   "id": "9d097efd0df9d3945e70b193947c7dea2e9a61a8dd0ae53ef766a7aeba10e42fi0",
+   "id": "b3f0ce0b21520620f84478809f402481fb9e53219e150d9aafac33ee0d0b9813i0",
     "meta": {
       "name": "Bitcoin Digits #53",
       "status": "Mythic",
@@ -935,7 +935,7 @@
     }
   },
   {
-   "id": "b580edf950f6111d5cbb227ba976d8f7fe2089983bb7fbcbdb880bc22dae3ea5i0",
+   "id": "9d2c589dae55aa45aaff5fc535404dcc7597b073774f1e11cc09069c6e74a3c6i0",
     "meta": {
       "name": "Bitcoin Digits #54",
       "status": "Mythic",
@@ -985,7 +985,7 @@
     }
   },
   {
-   "id": "28bcaa4eaf4bfe71cbe4e75e2c2bb1575b5aa768b412f9adc4b90d98f3e5ba97i0",
+   "id": "aa051f5cb44594dfb041587b3fd6784457eb63cfb5112be9a33420a405c90a34i0",
     "meta": {
       "name": "Bitcoin Digits #57",
       "status": "Mythic",
@@ -1000,7 +1000,7 @@
     }
   },
   {
-   "id": "ac54404db1e27c9fc87157d36b96f4228240abcf6f207687b314d9b64264cddai0",
+   "id": "87a336678740966bdf40ab99d3a9d3fe1e9a6da1f6ac947f8f1261477641e5e2i0",
     "meta": {
       "name": "Bitcoin Digits #58",
       "status": "Mythic",
@@ -1015,7 +1015,7 @@
     }
   },
   {
-   "id": "bc355a9c5d99ccce336d80e1d6bc096ebb4dfd562bb59fe937b5cd6ca01cefe7i0",
+   "id": "7e87627b13bbaef7d1c349d92c81f3f826a11888a05f5a9bce76d9b1bad13f73i0",
     "meta": {
       "name": "Bitcoin Digits #59",
       "status": "Mythic",
@@ -1035,7 +1035,7 @@
     }
   },
   {
-   "id": "9660739524af26881414b186c8d8b9a52c263180de62a468b4c2e9789e011054i0",
+   "id": "aae9b169ced8ca1dab579219c2b0bff6352134a640565a7fff155004f17d0243i0",
     "meta": {
       "name": "Bitcoin Digits #60",
       "status": "Mythic",
@@ -1050,7 +1050,7 @@
     }
   },
   {
-   "id": "cb6910b42c9b7b8c151e3f181ca0ac6c9ea2101985cb87455032b2ce1dc27685i0",
+   "id": "e538fdbb8cb18ff19e40276fd996a10b23af0cd9c26fd2c17147b0f63464a5dci0",
     "meta": {
       "name": "Bitcoin Digits #61",
       "status": "Mythic",
@@ -1085,7 +1085,7 @@
     }
   },
   {
-   "id": "ac9dbee87be18e03b9a5f1bf5b9e84c1a3774a515b7a43d73a55c56505bf56c6i0",
+   "id": "b444cf5733939135209960ab51a9f604248b8b96abb2bd241c849d5750a6c062i0",
     "meta": {
       "name": "Bitcoin Digits #63",
       "status": "Mythic",
@@ -1100,7 +1100,7 @@
     }
   },
   {
-   "id": "1fa88aa8a74f2f568620910061ab2e06ca0d99045d3a86fe317109d09bf8ece3i0",
+   "id": "6623f32d332e62f49ef822e1d2c1ab62f67ddb9a0fb57b9dd2d9f5aa9ba43ce5i0",
     "meta": {
       "name": "Bitcoin Digits #64",
       "status": "Mythic",
@@ -1180,7 +1180,7 @@
     }
   },
   {
-   "id": "7f0beb355adf7d26e84a12a85edd0f7962344fc206f1abc3b82ea3fb535b5a68i0",
+   "id": "74d4bef55d1167e2fe41db0b26970a0cb6acf49a94051f15b29e6fa4e98d7546i0",
     "meta": {
       "name": "Bitcoin Digits #69",
       "status": "Mythic",
@@ -1195,7 +1195,7 @@
     }
   },
   {
-   "id": "473827816b891fb95b08aecf82b4da3e7d300f2fdcf9f1508ee7e1c67e8f269ai0",
+   "id": "6995c3132c6df69b03809f052ab6438013aaf7caa491822a2df58caa7c987cc6i0",
     "meta": {
       "name": "Bitcoin Digits #70",
       "status": "Mythic",
@@ -1245,7 +1245,7 @@
     }
   },
   {
-   "id": "2cd08738d384fd6d28fb372208d94ffe0e375533e0aeaacbc105e1705f65f2c7i0",
+   "id": "992e0fab08a13e9b3946b6e178808a93ac17302a583f9094a5bb7d9edbd0c01di0",
     "meta": {
       "name": "Bitcoin Digits #73",
       "status": "Mythic",
@@ -1265,7 +1265,7 @@
     }
   },
   {
-   "id": "d7b30fcc5e5a20322c746c684a1366b5a65fff8dd49871b30f011ce11aac1e76i0",
+   "id": "016832ce6d47ad27992b88be342213e99eab3ed7a4b3463509b299269939a78fi0",
     "meta": {
       "name": "Bitcoin Digits #74",
       "status": "Mythic",
@@ -1295,7 +1295,7 @@
     }
   },
   {
-   "id": "918057ed02e09a861e14d1ad6256c829b9d4770a2c4b1821af1f5c6444032f16i0",
+   "id": "3cf3b6d88eb374cf4a303463fe08a880ab5c6e8e6f6465544285760cbd27dce7i0",
     "meta": {
       "name": "Bitcoin Digits #76",
       "status": "Mythic",
@@ -1310,7 +1310,7 @@
     }
   },
   {
-   "id": "fb7b333c815287937281c9ae3f489dc954f27bb32d7fd42a5d32baebd96251c4i0",
+   "id": "1d837b0659dfa7dee57cc3e4321bd589522abc92cba4a3d98034c59dafd4b50ei0",
     "meta": {
       "name": "Bitcoin Digits #77",
       "status": "Mythic",
@@ -1340,7 +1340,7 @@
     }
   },
   {
-   "id": "023dc89dc85899d5018714078374a0cc8f808ea0a9387097b64c4bb9d3d36cbci0",
+   "id": "cd53ccbf3a472a5ab96073787cdc7187509680020bd77830b6aac7ab24cd2551i0",
     "meta": {
       "name": "Bitcoin Digits #79",
       "status": "Mythic",
@@ -1360,7 +1360,7 @@
     }
   },
   {
-   "id": "bc625899e346bc23057f3b482ca371d217c2bf4bb729192025da5a1c61e53c2bi0",
+   "id": "056a6b6092999d46d03b7ea744e4d404f991db4ff0d19c285297198d0aed4bdbi0",
     "meta": {
       "name": "Bitcoin Digits #80",
       "status": "Mythic",
@@ -1390,7 +1390,7 @@
     }
   },
   {
-   "id": "2476a1742f2a56b07a51de07a6ecb61d5622a3b3e0108f231b31132df1fbad8fi0",
+   "id": "79d48f44215f3e0e09d487726e8ce49d0e343761d5605b67f15671a02acb2808i0",
     "meta": {
       "name": "Bitcoin Digits #82",
       "status": "Mythic",
@@ -1425,7 +1425,7 @@
     }
   },
   {
-   "id": "41fa899efabb3ba1dd5faa68f181647cdc4135b22a5329b82e400579f1f0f6d9i0",
+   "id": "c6b1787218aadea69913d3e95c189c578d40533a09d08731361a6bdb0dc0e2eei0",
     "meta": {
       "name": "Bitcoin Digits #84",
       "status": "Mythic",
@@ -1455,7 +1455,7 @@
     }
   },
   {
-   "id": "6cb89e73248c7bbe06b8f4e7f5530ebadc09e3d3a58033e759d0b20d31953386i0",
+   "id": "85599f95d314be4d861796c18f2b751a0d97af8a40be4a8b6966b366da529ac5i0",
     "meta": {
       "name": "Bitcoin Digits #86",
       "status": "Mythic",
@@ -1525,7 +1525,7 @@
     }
   },
   {
-   "id": "3926a0af7f47a8939d0fc8d10322c75e53ade5d25913e4f6cd7b2d8750c0125ci0",
+   "id": "58d0011ffcbb00ad7bc4570d8b514198a0c342296acd31798e748a4ea558943ei0",
     "meta": {
       "name": "Bitcoin Digits #90",
       "status": "Mythic",
@@ -1555,7 +1555,7 @@
     }
   },
   {
-   "id": "b23df14bf2be736d4a0952b1a8c4a79cd74440ece21c8628333569984b64c532i0",
+   "id": "9256cb728db2bb4a33beae00e42826a571703cd34b7cbf5d8b0fd90b12873e79i0",
     "meta": {
       "name": "Bitcoin Digits #92",
       "status": "Mythic",
@@ -1585,7 +1585,7 @@
     }
   },
   {
-   "id": "30327338579c1c298106c9f04a6d8db518fd2c63863a197bce1171f9a552e469i0",
+   "id": "7cad1a0504b7f990a54b5c858de880bb8bb889d6095c112c13e4643b9003485di0",
     "meta": {
       "name": "Bitcoin Digits #94",
       "status": "Mythic",
@@ -1615,7 +1615,7 @@
     }
   },
   {
-   "id": "73a102b6fff96d36005bd6fae6073fb516d85413fab7ebef45f92e3d15ddf4c3i0",
+   "id": "94b3c45b1a5893ce204a247f9822e1450461de91d6593f56f28ac49a3226714ci0",
     "meta": {
       "name": "Bitcoin Digits #96",
       "status": "Mythic",
@@ -1630,7 +1630,7 @@
     }
   },
   {
-   "id": "05f01180e188f1993cb3367416f8a5d22ccfb44f171ada9566217d326c390143i0",
+   "id": "6fe9ef91c30bd6abd42df79c05152d49413ff7c4b53b4a205182307d58777bbbi0",
     "meta": {
       "name": "Bitcoin Digits #97",
       "status": "Mythic",
@@ -1650,7 +1650,7 @@
     }
   },
   {
-   "id": "19e4318a98f3901478552d80c23a1a6b42d7a46960380945a38dcb5333bff701i0",
+   "id": "52774c237e1602f8e58dd89096480e25d05e8bec679ebff714744cb1be5c5052i0",
     "meta": {
       "name": "Bitcoin Digits #98",
       "status": "Mythic",


### PR DESCRIPTION
I updated the list of Bitcoin digits, because I found a small problem with some two-digit codes (the owner put a /n (line break) after a couple of digits, which made me look for other numbers) I write only those digits in the collection that's codes contain only the number (without line breaks) and have the earliest inscription.