### PR TITLE
Correction of an "inscription_icon" data

### DIFF
--- a/collections/wordinals/meta.json
+++ b/collections/wordinals/meta.json
@@ -6,5 +6,5 @@
     "twitter_link": "https://twitter.com/w_ordinals",
     "discord_link": "",
     "website_link": "https://wordinals.art",
-    "inscription_icon": "https://ordinals.com/inscription/019145fff68d890b6ea6e6486e61221d412d90b9a7634ccd02628d365d0c1aeei0"
+    "inscription_icon": "019145fff68d890b6ea6e6486e61221d412d90b9a7634ccd02628d365d0c1aeei0"
 }


### PR DESCRIPTION
Because the "inscription_icon:" is not displaying on marketplaces, I have removed the entire URL and kept only the inscription ID, following the approach adopted by other collections.

I apologize for any inconvenience caused.