### PR TITLE
Add 10² Islands collection

### DIFF
--- a/collections/10-square-islands/inscriptions.json
+++ b/collections/10-square-islands/inscriptions.json
@@ -1,0 +1,702 @@
+[
+    {
+        "id": "2f2c5da95293c990b8fdcbc862f4a09f007ff7f91cc5899c568fad007ef04e0ei0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #01"
+        }
+    },
+    {
+        "id": "f75255c9d36b904d18712b9ae85197bc899bb369abf6da44aedfdab27f5f1f66i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #02"
+        }
+    },
+    {
+        "id": "a8f3103a357dc134a08fe47831931c9041eb7b4f3ca89e47be45a34c2a22e1a7i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #03"
+        }
+    },
+    {
+        "id": "8165e39a2950cc65ff70340e0f5791c304481ec677d56eeb3c0115e3d4082d62i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #04"
+        }
+    },
+    {
+        "id": "f41668fbf5761d0ca77e372df48b39de840169c9aaba1621f137633fa4c3e791i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #05"
+        }
+    },
+    {
+        "id": "880fc3603852e4c02af914411c6608a1ad85c3108b7a947beb58ae44ad32cbcci0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #06"
+        }
+    },
+    {
+        "id": "e3e13af56f701d00b17edb627b22f021dad34ba0475a13bbd8cda38458658c79i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #07"
+        }
+    },
+    {
+        "id": "aa376fff46a2c4762d1cb5e5dbf0a3720bd7187b39c81b07175e92dc5a07ddc4i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #08"
+        }
+    },
+    {
+        "id": "fd0aa9aa36c8190740f1263ac2565ccc0f2f344d8f88609e70cd2011df662e1ai0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #09"
+        }
+    },
+    {
+        "id": "bed45a06699fdf8791ad4ef0587dc788dfec64a16685646cd4f91d74fc553b7ci0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #01"
+        }
+    },
+    {
+        "id": "28cb408d7027a8f6af4ea1af1e4727e2c06aa39829c37938f9b09e4987224b21i0",
+        "meta": {
+            "attributes": [],
+            "name": "Merge Marina #10"
+        }
+    },
+    {
+        "id": "74d208fe3b266ab353a91135e66a0e5f7ae9f1625b720c2a643bed0609e97fc6i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #02"
+        }
+    },
+    {
+        "id": "554a7ddacdb5200c45db43059e62530f431301a6e20e67c12ff63616568da30di0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #03"
+        }
+    },
+    {
+        "id": "9c6a990936a86a2c4893b525dedee936df7277bea4c3154e2a93b9467ac219d7i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #04"
+        }
+    },
+    {
+        "id": "e2bbac8f508f3fc21fc59d1b5273fd874edbd19df21a817cd51fc5a414055ad5i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #05"
+        }
+    },
+    {
+        "id": "5fbf774456c704bff508bb7edf60a4defd0f75f76933299c5f95671c23224776i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #06"
+        }
+    },
+    {
+        "id": "d7587159f71f85b66468bb00f78d926d56a92a85330505d2eca050b9e799bd6ci0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #07"
+        }
+    },
+    {
+        "id": "a76fb5c0e0795e176fc2296dd9ad02b5a3f0ed8521a1ec271730feccbe7274c1i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #08"
+        }
+    },
+    {
+        "id": "de73a63ebcb84d7b81d80ec74e6e7cacb782d8db68f0c019e63b6600bc4bd135i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #09"
+        }
+    },
+    {
+        "id": "b7586c9724d5bf4ad7bc931c97bacf2d6cc7b676c48608d9cd873824821793f3i0",
+        "meta": {
+            "attributes": [],
+            "name": "ASIC Isle #10"
+        }
+    },
+    {
+        "id": "5615f46966b35c54dfc7a67e41a30ae9ff426f4d7180d5d374011d476e403f80i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #01"
+        }
+    },
+    {
+        "id": "1527559b3c80c3c485fa8a497b951a36263fc9df123fc4adfe24956bccd493cfi0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #02"
+        }
+    },
+    {
+        "id": "711a0c79b9ece44f615adacad902d5bf9290b67f39d81e3e5f7571a2376530f2i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #03"
+        }
+    },
+    {
+        "id": "383230176be4093d4db19592d98e62a6e64c110d907a4935705093af07f438d8i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #04"
+        }
+    },
+    {
+        "id": "1ba005c9d64e13b78efe8c800f0c936de0040507c55cb77dce126de7a530aaddi0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #05"
+        }
+    },
+    {
+        "id": "0e237ded9b53d7794efeb6b2f5e3c83eb0c496112ea673f5dcd49af2f7094430i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #06"
+        }
+    },
+    {
+        "id": "f7df64054a16a855af5d6408b18bcb87803fcb403e10283937a1641384c8479bi0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #07"
+        }
+    },
+    {
+        "id": "5526263e055f3dd88c5cc8a98b86c7c3dc39cb405d661fa2feed89410a4a3650i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #08"
+        }
+    },
+    {
+        "id": "5d546f918876517ffa5f41934d156d729aa04dd0649e0d76a081e8df65f90ab8i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #09"
+        }
+    },
+    {
+        "id": "cf6a4e4e16a77af42a3a7206d763f00e67e21d26e6bf61f1a41b37d049d2ae23i0",
+        "meta": {
+            "attributes": [],
+            "name": "Shiba Shore #10"
+        }
+    },
+    {
+        "id": "7f503ab1b2d2f3f2386030819b498d4449906e9725ee88ca41783581c7a1d977i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #01"
+        }
+    },
+    {
+        "id": "531720c1c7a2e5f356cdfa5594aa1965bdd69dcfa63bc26c53ccead5b0a8332ci0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #02"
+        }
+    },
+    {
+        "id": "8b972c1b1a1e13012c4f0bc7512721198df0724d24050a57e9d953816adf31ebi0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #03"
+        }
+    },
+    {
+        "id": "7ef7830caa1b89b9243dbd4ee6beacc5c5ddc0663e2db54f59d26accb65bb501i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #04"
+        }
+    },
+    {
+        "id": "60b8235ee044e0a5870511ef7044bf39326a6cacad608af3156d9104f17f1652i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #05"
+        }
+    },
+    {
+        "id": "a7361560dad9cb5cc05bc5ea1bc5859fbca247d726787f30c8edebac3f012da7i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #06"
+        }
+    },
+    {
+        "id": "c3cf74aadd19d15bdd49a50532647f9707a296465a9e26ea7984b97a389e1d39i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #07"
+        }
+    },
+    {
+        "id": "421db0bde56331de59fc8b672185e59ff518284534c7d5f4a8e2e8171716ae15i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #08"
+        }
+    },
+    {
+        "id": "36c1f3ac45bae15decfa6f56de9d74d10c468f3ada1c6f601d4d6310557be015i0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #09"
+        }
+    },
+    {
+        "id": "e6519006e497032c811c14bf80943429df1c0d5c903af513c09e3bf34926fc5ci0",
+        "meta": {
+            "attributes": [],
+            "name": "Ether Bay #10"
+        }
+    },
+    {
+        "id": "9a543ec5919df36921811ac04870ee11a48f545b7a32107c22ef59a8c41af666i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #01"
+        }
+    },
+    {
+        "id": "50b511d0731654742d39b8ede31c2484206b90a974bd36bc041e85a90fafe966i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #02"
+        }
+    },
+    {
+        "id": "ca092259045b9409d27e59c61821ccd9ecb024d60895b7c446937bc1efce20e3i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #03"
+        }
+    },
+    {
+        "id": "e932ae622cffbebe196a8af40c5e04f2bd33e08e1bf8b0d25d33b7e1ba9fba19i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #04"
+        }
+    },
+    {
+        "id": "a10bfcdef71108e54e3a3bf037137c19b83074df060efe841f4f41885f4a79aai0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #05"
+        }
+    },
+    {
+        "id": "97dcf1c578a2f3256801098ed35e44786eb36ea8158bdbd8bbf62529723d835bi0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #06"
+        }
+    },
+    {
+        "id": "ac285c614b9ebddd512413f8be98dedd33811a668ebdab6fc0004822b13a797bi0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #07"
+        }
+    },
+    {
+        "id": "6181412732cbd7114122f80e6ad85e699ec149e1b1accd6850e7fefb28200dc6i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #08"
+        }
+    },
+    {
+        "id": "44c673d61212e4107762f782dc30dcd08217c0bbcb33c566b6792c299be58806i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #09"
+        }
+    },
+    {
+        "id": "94349d579cb64c2769ab2a07e601a2bc92aead74d9121c9ae4e4cd4a542499e1i0",
+        "meta": {
+            "attributes": [],
+            "name": "Mining Mesa #10"
+        }
+    },
+    {
+        "id": "e717cf2c4337a21d540ec6e53780a89564097f4007c9b639957ed369e7e12e4fi0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #01"
+        }
+    },
+    {
+        "id": "e345738919c1c4709ad3b184cc6fadcc82df0877ee4095360423d06df28bf06bi0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #02"
+        }
+    },
+    {
+        "id": "e69e7811691ef13bdde6af127d30d8fec48cb74e689feb572399745c15b4e64di0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #03"
+        }
+    },
+    {
+        "id": "547c04704a393c3d277a7aebc93451ad830900aa5e557cae4a8456442d2a1858i0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #04"
+        }
+    },
+    {
+        "id": "f836cddbf1275a2fb7195b59cf3b234ef0b5a79169c37e03c56143bd4bae977ei0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #05"
+        }
+    },
+    {
+        "id": "dc893a66ff895bfd68875aefc50d84798a521ad0019f5891f0a120dd93ff9115i0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #06"
+        }
+    },
+    {
+        "id": "6f90147e14ccd30f465abc610af7ffb57c184053096871629110a34492738ba3i0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #07"
+        }
+    },
+    {
+        "id": "41d1cef6da83ceb160f66eb9d8597118cd4c27e6bebc8e3a477b9ff6078716d3i0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #08"
+        }
+    },
+    {
+        "id": "819845ce53929e24f9b6e5e133ed105766c978dc0506188cc5bad9fb83824cbfi0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #09"
+        }
+    },
+    {
+        "id": "03d3fbafa1137933555c8aec6826b7b8b474019faa3a349bd688f099f7350066i0",
+        "meta": {
+            "attributes": [],
+            "name": "SegWit Strand #10"
+        }
+    },
+    {
+        "id": "5d9887a0dd1d8934434f4cd808ef5b41311a42c0e198ce042d396e430a76ce17i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #01"
+        }
+    },
+    {
+        "id": "e3a8a294e28c26a166caae22f85aa0547b1303dc0d5fc4608defb40b1a919298i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #02"
+        }
+    },
+    {
+        "id": "29f7e5c3b1bf8fdaa138b1519de4407a290ed6456d5fb4ef01d248230f1396e1i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #03"
+        }
+    },
+    {
+        "id": "73fbba4993f442c7aa9704b233e499ba6f62d8d1baec220021863b6184a210c6i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #04"
+        }
+    },
+    {
+        "id": "4d8fe23233e9410ca7d3fb90e825ea74cb7582a0ca6f2ba97f15c9c31690fb71i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #05"
+        }
+    },
+    {
+        "id": "3f3bbe6f0e1040c9942228f62ae6954e0a496365127cb1fbc18c46e2f3e2f70ai0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #06"
+        }
+    },
+    {
+        "id": "055dce6b634685b4f94c93b6de3674cf2a592fafe103f45a2c7d6eb9e74c97d3i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #07"
+        }
+    },
+    {
+        "id": "16fa1fedba21ccbe229a485e074fa04a3ab13b228e9fd973feb0711f933c3a3ci0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #08"
+        }
+    },
+    {
+        "id": "85c707cd3aa71d8a4a6e1a4b32f254479d6cd850ca176c674923cfa17eea315fi0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #09"
+        }
+    },
+    {
+        "id": "6a4235f33d824c96688049863424e9f73647f8cc1ec390bdd22e0cff30b852e5i0",
+        "meta": {
+            "attributes": [],
+            "name": "Lightning Lagoon #10"
+        }
+    },
+    {
+        "id": "c65200a5f24c2602630db55413f9aca8f058706ff87b688b606273d22ecab076i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #01"
+        }
+    },
+    {
+        "id": "1002695e82f17d3fb11b8e56a18a421884da43b66cd423ba515233c8305fcbd2i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #02"
+        }
+    },
+    {
+        "id": "86a471dab47908bbe092a241895e9e1bca37e77336ddb3f0430e97471a242e4ei0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #03"
+        }
+    },
+    {
+        "id": "144d4926147c99566f4c4c94c9df1a21853a6813f7c8ad34676b89c21d25bc99i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #04"
+        }
+    },
+    {
+        "id": "bce1eda5111ef98fdd9bb383cbb0dbdbb1020d683fdcb6cd53918ab24978072bi0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #05"
+        }
+    },
+    {
+        "id": "436cfeab841d59329c0ed5a6aa9a16f3a5517fea1f3aa2f9ad8d17de8dedb545i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #06"
+        }
+    },
+    {
+        "id": "ca24db0a3c886b35f46663acdfb88127dc111e6346f91ddc6939185fb81123bei0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #07"
+        }
+    },
+    {
+        "id": "7ecf55fe3812e17959470e9d9a11024ce5a47bbd459dbbe3d767309e8134c4d2i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #08"
+        }
+    },
+    {
+        "id": "887ace4454f1dd1021e1b273044511b48e532650074c50320dcaba5a4bbd2320i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #09"
+        }
+    },
+    {
+        "id": "f8de1dafa297d5bac9c01c2cb6b7880acb759d9235daf0e9d0f449adbef86b38i0",
+        "meta": {
+            "attributes": [],
+            "name": "ExaHash Haven #10"
+        }
+    },
+    {
+        "id": "045d81288ce06956dc3777ea5da75b0a5ace23d9085907741ebd6fc225f8124fi0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #01"
+        }
+    },
+    {
+        "id": "87174c6384cbca2335c1147d8943c3a3c67fd4ded511eb7f12740b8d45c11d0di0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #02"
+        }
+    },
+    {
+        "id": "1a5970ac978a21edafc673201b990969e3553c913e27af9e6aca21fe67f9e1cdi0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #03"
+        }
+    },
+    {
+        "id": "0c3ce082d03be021c19d155b6cd4fbc22d15e073d198bcf24d0478617ec97865i0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #04"
+        }
+    },
+    {
+        "id": "88e5dd99e085fc8e7cf2b35acc3e9f07f65ae37a381bfd939c1bc78fbde19a24i0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #05"
+        }
+    },
+    {
+        "id": "8579f6d9ec2110ad5a3e445f2cabb3d0d8dc96f064b13c6424b7e30a77397a12i0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #06"
+        }
+    },
+    {
+        "id": "054d0ea48c06a1b8ac48574c8230f821b96c4c132db077797d12473cb849fe76i0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #07"
+        }
+    },
+    {
+        "id": "b54d98b9d29ffbbed26b9ed539899604ca22c52cef12c46b480e1d7b298ad556i0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #08"
+        }
+    },
+    {
+        "id": "08a093fffd868a69e85361db806d752ea7793bb7e4b9573a983613c4c9b97b0di0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #09"
+        }
+    },
+    {
+        "id": "3e0ecffcede3746754fe0166558dd68abebbbe4811f256763e2f8ca35de8ce72i0",
+        "meta": {
+            "attributes": [],
+            "name": "Halving Harbor #10"
+        }
+    },
+    {
+        "id": "270e7a2bc2da2a1fb61e0c991f876d4e25c7a383c75be9b9b48cb4ffc0152468i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #01"
+        }
+    },
+    {
+        "id": "32fe1376f6db4a18f0bf057e7f9f2c9beac53a97a633a07011e9bb1a202deecdi0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #02"
+        }
+    },
+    {
+        "id": "dfb73f7f4b9ddd0e58820f4edb56ad9d07893e7c1ee4173d5140ac96886fae60i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #03"
+        }
+    },
+    {
+        "id": "924eb41c5bf845fd7e55690690226a859e84f98796db6245eefd337791201be0i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #04"
+        }
+    },
+    {
+        "id": "38f937764ca51f1e3a36507fde2fd4cca4d27d59b5df94255f2ed21c4db370e9i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #05"
+        }
+    },
+    {
+        "id": "b4f9baccf171a85bde4b512f4214c7a081b3ea2b0f13827c1907de07051d58e0i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #06"
+        }
+    },
+    {
+        "id": "8b84a14b1d23d17d6552bcb2fd99956a8527736ee61493cd3869544a627e66f6i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #07"
+        }
+    },
+    {
+        "id": "d390f9152e42fc18bb8d4a4700d645f56897f6c73b41698d267636e757bab906i0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #08"
+        }
+    },
+    {
+        "id": "5284945c4dcce9475b02b9fb4614674cf9e925a702c07f0da0daa0f49e4fa6cbi0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #09"
+        }
+    },
+    {
+        "id": "6ba9f6c9360d6984f73564fb3755ea05dd5bc5f5096d691f5c55f4c23054e37ei0",
+        "meta": {
+            "attributes": [],
+            "name": "Volcano Cove #10"
+        }
+    }
+]

--- a/collections/10-square-islands/meta.json
+++ b/collections/10-square-islands/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "10² Islands",
+  "inscription_icon": "270e7a2bc2da2a1fb61e0c991f876d4e25c7a383c75be9b9b48cb4ffc0152468i0",
+  "supply": "100",
+  "slug": "10-square-islands",
+  "description": "In homage to the milestones that have defined Proof-of-Work blockchains over the last decade, f2pool inscribes 10 bespoke artworks onto the Bitcoin network. 10² Islands features 10 sub-categories, each embodying a milestone. They include ASIC Isle, Shiba Shore, Ether Bay, Mining Mesa, SegWit Strand, Lightning Lagoon, ExaHash Haven, Halving Harbor, Volcano Cove, and Merge Marina.",
+  "twitter_link": "https://twitter.com/f2pool_official",
+  "discord_link": "https://discord.gg/KapbeYNN9e",
+  "website_link": "https://www.f2pool.com/nft"
+}


### PR DESCRIPTION
In homage to the milestones that have defined Proof-of-Work blockchains over the last decade, f2pool inscribes 10 bespoke artworks onto the Bitcoin network. 10² Islands features 10 sub-categories, each embodying a milestone. They include ASIC Isle, Shiba Shore, Ether Bay, Mining Mesa, SegWit Strand, Lightning Lagoon, ExaHash Haven, Halving Harbor, Volcano Cove, and Merge Marina.