### PR TITLE
Fix meta, and ask for <object> display again

### DIFF
--- a/collections/ordinal-clocks/inscriptions.json
+++ b/collections/ordinal-clocks/inscriptions.json
@@ -3,84 +3,96 @@
     "id": "0bd9fcce9b49f6959c43534b5df7ff4f29de23fd97bd5d34ce2be8d57f9d12c7i0",
     "meta": {
       "name": "ORDINAL CLOCKS #1",
-      "type": "ORDINAL CLOCKS #1"
+      "status": "normal",
+      "rank": 1
     }
   },
   {
     "id": "c38c90919f3c5239bbde75a5faa519ee66778bdf47b7fcb669208453601cb34di0",
     "meta": {
       "name": "ORDINAL CLOCKS #2",
-      "type": "ORDINAL CLOCKS #2"
+      "status": "normal",
+      "rank": 2
     }
   },
   {
     "id": "ca40c7740958fe8c1f0b16f07ae26c75da3f897b8e70676298e167f7ee9ee481i0",
     "meta": {
       "name": "ORDINAL CLOCKS #3",
-      "type": "ORDINAL CLOCKS #3"
+      "status": "normal",
+      "rank": 3
     }
   },
   {
     "id": "d13dece01c28062d54195b1b49e1d5a9e900c8b5db2642ef062a7f1ba211f8f7i0",
     "meta": {
       "name": "ORDINAL CLOCKS #4",
-      "type": "ORDINAL CLOCKS #4"
+      "status": "normal",
+      "rank": 4
     }
   },
   {
     "id": "7dd26e65019adc0b0578b1c11a0e7f957787947c266b5c475e2db932aabf76fbi0",
     "meta": {
       "name": "ORDINAL CLOCKS #5",
-      "type": "ORDINAL CLOCKS #5"
+      "status": "normal",
+      "rank": 5
     }
   },
   {
     "id": "f48300b4a6c59a5fc6287bf50ed16a37823cc7665a7d93de6e0efa4d962800c0i0",
     "meta": {
       "name": "ORDINAL CLOCKS #6",
-      "type": "ORDINAL CLOCKS #6"
+      "status": "normal",
+      "rank": 6
     }
   },
   {
     "id": "77d081eb3e51333044d455df196565343e91eba650ff99535598b1adeff3366di0",
     "meta": {
       "name": "ORDINAL CLOCKS #7",
-      "type": "ORDINAL CLOCKS #7"
+      "status": "normal",
+      "rank": 7
     }
   },
   {
     "id": "14062671de4051553bc2e2e7469bc891644e5bfb9d4e093f16f7270ed3d0f962i0",
     "meta": {
       "name": "ORDINAL CLOCKS #8",
-      "type": "ORDINAL CLOCKS #8"
+      "status": "normal",
+      "rank": 8
     }
   },
   {
     "id": "7fdb79aa2ae70b845d9d5c3515335f4a3b99af86df27e65c202887fe152befeai0",
     "meta": {
       "name": "ORDINAL CLOCKS #9",
-      "type": "ORDINAL CLOCKS #9"
+      "status": "normal",
+      "rank": 9
     }
   },
   {
     "id": "259a8c7d74d66a99fceb20885bfc0cd7d08f10f8faad766c2d5be74c12da6cbci0",
     "meta": {
       "name": "ORDINAL CLOCKS #10",
-      "type": "ORDINAL CLOCKS #10"
+      "status": "normal",
+      "rank": 10
     }
   },
   {
     "id": "e1305882438a6044cd9d62bfdc9d5cb3698d302f4d2f763b19a9782f251fc876i0",
     "meta": {
       "name": "ORDINAL CLOCKS #11",
-      "type": "ORDINAL CLOCKS #11"
+      "status": "normal",
+      "rank": 11
     }
   },
   {
     "id": "080fb13c584234566e96385364351b5c3ba0d0b710f752b55e406df5491e698ci0",
     "meta": {
       "name": "ORDINAL CLOCKS #12",
-      "type": "ORDINAL CLOCKS #12"
+      "status": "normal",
+      "rank": 12
     }
   }
   ]


### PR DESCRIPTION
My collection is currently being displayed incorrectly on Ordinals Wallet. The files are SVG's, but the website renders them as IMG, meaning the Javascript doesn't execute.

This is a sub 1-million collection that is time-reactive and functions as an actual clock. But right now none of the functionality works. 

Could you please display these inscriptions as OBJECT tags? for example: \<object data="inscriptionurl">\
This simple change will fix the display and make the collection work correctly. Thank you! 

I've attached an image of what it currently looks like, and a video with the website code fixed to show the correct display. 

<img width="1305" alt="Screen Shot 2023-05-19 at 10 08 33 AM" src="https://github.com/ordinals-wallet/ordinals-collections/assets/68250041/11a9be1c-3a46-4de7-97c2-6ae1dd8e8a6c">
<img width="435" alt="Screen Shot 2023-05-18 at 10 51 18 AM" src="https://github.com/ordinals-wallet/ordinals-collections/assets/68250041/ecee6e37-ef04-4b9c-9330-e96466db86b6">

https://github.com/ordinals-wallet/ordinals-collections/assets/68250041/786342e7-131d-47dd-b428-5d151bab8b07