### PR TITLE
Remove Scam OMB Discord Link

### DIFF
--- a/collections/omb/meta.json
+++ b/collections/omb/meta.json
@@ -1,6 +1,6 @@
 {
   "description": "--- .-. -.. .. -. .- .-.. / -- .- -..- .. / -... .. --.. / -.--. --- -- -... -.--.-",
-  "discord_link": "https://discord.gg/Grws8uBy",
+  "discord_link": "",
   "icon": "https://turbo.ordinalswallet.com/inscription/preview/fbc1cd54b77f9b998dd16b8bd8f64c46590b8f1035f8d24461055ac8a00dc1a7i0",
   "inscription_icon": "fbc1cd54b77f9b998dd16b8bd8f64c46590b8f1035f8d24461055ac8a00dc1a7i0",
   "name": "Ordinal Maxi Biz (OMB)",


### PR DESCRIPTION
The current Discord link is a run by a wallet drainer with a fake bitcheck link in the verify channel.