### PR TITLE
Yelo Update inscriptions.json

### DIFF
--- a/collections/yelo/inscriptions.json
+++ b/collections/yelo/inscriptions.json
@@ -11100,7 +11100,7 @@
     }
   },
   {
-    "id": "0ca035777c5f1e3e6005c633a9f3e30d6e35c75b81e669e4949bbbd21c975f39i0",
+    "id": "b40de5727f0f010738566e8bd7d366ef54d31b149cdf59a71de705838030cb06i0",
     "meta": {
       "attributes": [
         {
@@ -11113,30 +11113,30 @@
         },
         {
           "trait_type": "Clothing",
-          "value": "Gold-Medalion-Gray-Shirt"
+          "value": "Skellington"
         },
         {
           "trait_type": "Ears",
-          "value": "Echo-Chambers"
+          "value": "Sound-Catchers"
         },
         {
           "trait_type": "Eyes",
-          "value": "Yelo-Box-Shades"
+          "value": "3D"
         },
         {
           "trait_type": "Head",
-          "value": "Lava-Octo-Hat"
+          "value": "Mega"
         },
         {
           "trait_type": "Mouth",
-          "value": "The-Lampshade"
+          "value": "Full-Beard-Smile"
         },
         {
           "trait_type": "Nose",
-          "value": "Inhaler"
+          "value": "Exhaler"
         }
       ],
-      "name": "BTC YELO #42"
+      "name": "BTC YELO #476"
     }
   },
   {


### PR DESCRIPTION
Found a duplicate, I would like to replace BTC Yelo 42 with the inscription ID 0ca035777c5f1e3e6005c633a9f3e30d6e35c75b81e669e4949bbbd21c975f39i0 with b40de5727f0f010738566e8bd7d366ef54d31b149cdf59a71de705838030cb06i0. BTC YELO 476 was added by mistake as there is already a BTC Yelo 42.