### PR TITLE
fix /bitcoiny00ts double listing

### DIFF
--- a/collections/bitcoiny00ts/inscriptions.json
+++ b/collections/bitcoiny00ts/inscriptions.json
@@ -1,0 +1,716 @@
+[
+  {
+    "id": "0ac722563fb1710a94a4202a6fd69bb4db7ad094707ff32c2c21e2189d958f71i0",
+    "meta": {
+      "name": "bitcoiny00t #30"
+    }
+  },
+  {
+    "id": "06a4138221633e248ad18c81b0b7b85fbe5b6c1d35e4369793a4e266892053d8i0",
+    "meta": {
+      "name": "bitcoiny00t #123"
+    }
+  },
+  {
+    "id": "4d80316231a7cb5a35375faa09240e681e0a4b08fe482bd7dff1b98336c83324i0",
+    "meta": {
+      "name": "bitcoiny00t #94"
+    }
+  },
+  {
+    "id": "b947cc5d2ffc240eff894ed345a2b60471af2c8280d9313105f7401b31dcb70ci0",
+    "meta": {
+      "name": "bitcoiny00t #117"
+    }
+  },
+  {
+    "id": "5da5b4b8a8d04fd42578feaaf60249012c034b06c2e04a60af0631050a15efefi0",
+    "meta": {
+      "name": "bitcoiny00t #112"
+    }
+  },
+  {
+    "id": "a24372d9213bbd327aa38b41bc16ba3a0b8cb40f77802e44d891471401e1c1c4i0",
+    "meta": {
+      "name": "bitcoiny00t #110"
+    }
+  },
+  {
+    "id": "e86df187d585ebb8d9e833e24477893ae72b1db12d57b879afc0ad8a139dc3cbi0",
+    "meta": {
+      "name": "bitcoiny00t #109"
+    }
+  },
+  {
+    "id": "c0bad52f1cf6b587a3fe37ee82acbfbf47522f60ba9f7d9282305ac5bdc36dc1i0",
+    "meta": {
+      "name": "bitcoiny00t #73"
+    }
+  },
+  {
+    "id": "c09ca8c94a78bafef983e3c279d453b676f42af5064cf21edeaa07b09477e34bi0",
+    "meta": {
+      "name": "bitcoiny00t #48"
+    }
+  },
+  {
+    "id": "e5bcfdf5a103f402b4e3deb4bbd51eb4a2755ce24733b444ca8bee1e773fff7fi0",
+    "meta": {
+      "name": "bitcoiny00t #91"
+    }
+  },
+  {
+    "id": "1da7fad4f156bcf6b071b6a76d1f26667b0d5595c454575c6773c56324b67298i0",
+    "meta": {
+      "name": "bitcoiny00t #105"
+    }
+  },
+  {
+    "id": "7206fd7bbbecb6dcdb51bd77b0f6bb19e76327b42df284ceb3f6a875cb27e8b6i0",
+    "meta": {
+      "name": "bitcoiny00t #111"
+    }
+  },
+  {
+    "id": "9e84a6fca55a3edc5244804b0b04c6e189f725a0b8b745aa3082da606f682d1di0",
+    "meta": {
+      "name": "bitcoiny00t #106"
+    }
+  },
+  {
+    "id": "b8218dd8cb66516bccffcccfd73058b4a721a1b95b5ec6992fc6e11cef887d26i0",
+    "meta": {
+      "name": "bitcoiny00t #113"
+    }
+  },
+  {
+    "id": "bc79bd220f9d8e59d3ca3178f322e55dc4b5328c9455a7a9fb1d5881eb169878i0",
+    "meta": {
+      "name": "bitcoiny00t #104"
+    }
+  },
+  {
+    "id": "bf7b8be8a748a3502a3cddd79e4986007048d9455361a10b4156f1bee368572bi0",
+    "meta": {
+      "name": "bitcoiny00t #107"
+    }
+  },
+  {
+    "id": "cb2b516a1ea01cb47ba3bb446cd17a747e2354baa044b253ebf720c46acbbf94i0",
+    "meta": {
+      "name": "bitcoiny00t #108"
+    }
+  },
+  {
+    "id": "b24155ed39318b9207b863a4984499305d2a82bdcc28ba7308e13e19567009a1i0",
+    "meta": {
+      "name": "bitcoiny00t #11"
+    }
+  },
+  {
+    "id": "584704b4b5a99ccfaf3dcc181d7f12174ec1b01eae0961beb9d030b395cca70ai0",
+    "meta": {
+      "name": "bitcoiny00t #23"
+    }
+  },
+  {
+    "id": "b312de8ac9ed2d40e38fa62d8071eb2fbaef1be5ca9309095849063372c11eaai0",
+    "meta": {
+      "name": "bitcoiny00t #21"
+    }
+  },
+  {
+    "id": "16cc63fd6b92894e20f0c3dd3cc67164939877b3aea94181f78eceb8bb1438b9i0",
+    "meta": {
+      "name": "bitcoiny00t #20"
+    }
+  },
+  {
+    "id": "ad52dc400ebbac0550e7822bc64dbe115423ebf40192b24f3b6d6f64f9ffdee6i0",
+    "meta": {
+      "name": "bitcoiny00t #22"
+    }
+  },
+  {
+    "id": "cfbca1b2c481fd791329c14293a286c3f4aaa8cb0dd8e12374b91fc42f52763fi0",
+    "meta": {
+      "name": "bitcoiny00t #37"
+    }
+  },
+  {
+    "id": "466437d8df9f716d23032e6e8d3208733c578df5d7a640877d474e762cc912e4i0",
+    "meta": {
+      "name": "bitcoiny00t #3"
+    }
+  },
+  {
+    "id": "9c32c4ee32d3420150ad74636896c275b78e759b52d2e28a2a9cd0a91e901a3bi0",
+    "meta": {
+      "name": "bitcoiny00t #0"
+    }
+  },
+  {
+    "id": "a98483f1725fa9e69e7afc78fde94511b5444b6211f346da703e7eba8938054ei0",
+    "meta": {
+      "name": "bitcoiny00t #92"
+    }
+  },
+  {
+    "id": "a3a48445a59a6d3e1a311f5d18c56c7007bc184417171f7a0abe68ebae5b16f4i0",
+    "meta": {
+      "name": "bitcoiny00t #29"
+    }
+  },
+  {
+    "id": "77f66b31ed841c666340eda6c21480dd2cca13b419ec1d18b2f386782b9452bei0",
+    "meta": {
+      "name": "bitcoiny00t #61"
+    }
+  },
+  {
+    "id": "43ad801a68438f361a4473e569ad0fe52edc1411651cbedbb9207031813c8391i0",
+    "meta": {
+      "name": "bitcoiny00t #57"
+    }
+  },
+  {
+    "id": "7e2f8e1dd472c6ae086ebde49518afec55045127c9bbdd22f6e590720004010ei0",
+    "meta": {
+      "name": "bitcoiny00t #19"
+    }
+  },
+  {
+    "id": "df69985ae917a463a9da57f58e424799deac9ac7c4acf9facf94d27248bc8f7ci0",
+    "meta": {
+      "name": "bitcoiny00t #13"
+    }
+  },
+  {
+    "id": "6390f14dbd15dfaa18429a04c20e7954be5206dbbb1108f574cc55f1eef49363i0",
+    "meta": {
+      "name": "bitcoiny00t #93"
+    }
+  },
+  {
+    "id": "06417df76482a3c6d06fd445e83be6f522e227c0563b333dffb833a1a9032216i0",
+    "meta": {
+      "name": "bitcoiny00t #2"
+    }
+  },
+  {
+    "id": "0ebe3a8c1e447f0eae0f37285141e631f3bb594d88e83bf3ac57364ff9c2374bi0",
+    "meta": {
+      "name": "bitcoiny00t #15"
+    }
+  },
+  {
+    "id": "0f5cbdebe7e11625370d2911b66cbce95200d438bea38b7dd778e649979392cfi0",
+    "meta": {
+      "name": "bitcoiny00t #62"
+    }
+  },
+  {
+    "id": "13a45225f89d582ad2b61c14f9b9cbbc91cacf329511604c7f42aca67c6271edi0",
+    "meta": {
+      "name": "bitcoiny00t #71"
+    }
+  },
+  {
+    "id": "146d461ec09f04d3cef03a6dfde8fc858cb94a372f0496c2c7beb1a8f24a59dei0",
+    "meta": {
+      "name": "bitcoiny00t #63"
+    }
+  },
+  {
+    "id": "14c1e68ff6889276a534047fbc2486344f5932e1f1b660679badd653ad9643f4i0",
+    "meta": {
+      "name": "bitcoiny00t #42"
+    }
+  },
+  {
+    "id": "16c5b24fd94c663ceef685dff2bbef01e847e0038cb0daa2b345a7d82c849593i0",
+    "meta": {
+      "name": "bitcoiny00t #10"
+    }
+  },
+  {
+    "id": "1ac6194c295c033d5331fbb40b466d231e1e099272a5948a3d0ea410851aa6d8i0",
+    "meta": {
+      "name": "bitcoiny00t #25"
+    }
+  },
+  {
+    "id": "1bac770f0f93a3e0c9cd2a3db6a0ff2501fdb3bff261bae85a6ddab279039e50i0",
+    "meta": {
+      "name": "bitcoiny00t #16"
+    }
+  },
+  {
+    "id": "2b15aa2733e8f636455050c4d4af97d26615713a28851637c195a1d110345735i0",
+    "meta": {
+      "name": "bitcoiny00t #84"
+    }
+  },
+  {
+    "id": "304a96d125e2427fe5591b5a4f1abb4e7873d079a5955be0331fd6d5aa6272cbi0",
+    "meta": {
+      "name": "bitcoiny00t #98"
+    }
+  },
+  {
+    "id": "3937eb4aff0b954010397c04e86bd8422b869e5f0bf69de7bc7e9496e72b53dbi0",
+    "meta": {
+      "name": "bitcoiny00t #121"
+    }
+  },
+  {
+    "id": "4159e6df5cb9098a4f549e325f45afea942de90b9c7ab2e2bb7c3799e15a46d0i0",
+    "meta": {
+      "name": "bitcoiny00t #66"
+    }
+  },
+  {
+    "id": "415ae5af5709587ddc22fcb692832d14c405cfed5668198a7085e5b3569d0c51i0",
+    "meta": {
+      "name": "bitcoiny00t #102"
+    }
+  },
+  {
+    "id": "424569a048b5860926414b160d007c41f189573696f01e9fb30157bf5c5a1cfei0",
+    "meta": {
+      "name": "bitcoiny00t #90"
+    }
+  },
+  {
+    "id": "4355a90743dec6f9c22905376bf4716459e05c37e8e8d56a9108857e19c7a950i0",
+    "meta": {
+      "name": "bitcoiny00t #50"
+    }
+  },
+  {
+    "id": "438ccc177886650d2788103da1673234bf965db26e6ca254d9859a0e46ffd50fi0",
+    "meta": {
+      "name": "bitcoiny00t #54"
+    }
+  },
+  {
+    "id": "44cbd6250d163b393c9f1a1ecb758e5f60ffc7c6584b2498b08f069a89842e50i0",
+    "meta": {
+      "name": "bitcoiny00t #96"
+    }
+  },
+  {
+    "id": "4713cf3688a14241a34b3b60917db3696c29d06545610c626602d15f7be418e9i0",
+    "meta": {
+      "name": "bitcoiny00t #114"
+    }
+  },
+  {
+    "id": "48c63da187d12a920fe52524226c18ad71ab3dfae3bf6d5defcbdb3234f97dcci0",
+    "meta": {
+      "name": "bitcoiny00t #28"
+    }
+  },
+  {
+    "id": "4edf5c6ac303879f87ae95fd195682f770bfe2f69a30777848e2c3cef7bf676bi0",
+    "meta": {
+      "name": "bitcoiny00t #56"
+    }
+  },
+  {
+    "id": "4f1c0bfc765ebc1d0127ccffd4ab9e8a1fed04300a3566dd308cb9211099979ci0",
+    "meta": {
+      "name": "bitcoiny00t #60"
+    }
+  },
+  {
+    "id": "4f54bb95ff8d95a4f89300dd16533701d34355af0f36957d22330517160fb67di0",
+    "meta": {
+      "name": "bitcoiny00t #81"
+    }
+  },
+  {
+    "id": "59cf072af65658f728d2407c0bb2171db7d70f79f85f2f2777db2fbe304c4a41i0",
+    "meta": {
+      "name": "bitcoiny00t #82"
+    }
+  },
+  {
+    "id": "5b09cbf6a5de5b2310874d4bf5694d30315a29a311f5e6fb8387b689ffa9c095i0",
+    "meta": {
+      "name": "bitcoiny00t #122"
+    }
+  },
+  {
+    "id": "5b5c72fe5c5d82742b8ecf3ada8b1708500e7bbd23529b978e67543330451934i0",
+    "meta": {
+      "name": "bitcoiny00t #46"
+    }
+  },
+  {
+    "id": "5bd05d19018a0554e0aa8a45913f638968006adf9d263c6c4843e08f9a6b629ai0",
+    "meta": {
+      "name": "bitcoiny00t #87"
+    }
+  },
+  {
+    "id": "5d34ba9b89088633ebfb2cb9c1b942d916fef306ae23023d2af6e4b34513c4ebi0",
+    "meta": {
+      "name": "bitcoiny00t #32"
+    }
+  },
+  {
+    "id": "6018df866a88ced18f16bfbef7d1d90e36f909a24610133663ff34b0065c61e0i0",
+    "meta": {
+      "name": "bitcoiny00t #120"
+    }
+  },
+  {
+    "id": "60c483724864db1c62552ce04dfea26c3fd0e239c64d32e6b5c8d41af2b68d9di0",
+    "meta": {
+      "name": "bitcoiny00t #99"
+    }
+  },
+  {
+    "id": "61c9efc4189f1827974f0134697f551b7258b839e3507f8a50bd2b82f5247c9ei0",
+    "meta": {
+      "name": "bitcoiny00t #45"
+    }
+  },
+  {
+    "id": "62d54f978fa7de97e52a491afecca6dfce485f706f8401280696dc5f63bd8e56i0",
+    "meta": {
+      "name": "bitcoiny00t #78"
+    }
+  },
+  {
+    "id": "6b6ee3985dc9b3d0c07e217970b06e7f6a6c37b32921a0afa9d1491b3f864f43i0",
+    "meta": {
+      "name": "bitcoiny00t #95"
+    }
+  },
+  {
+    "id": "738f4bf5760e637bce414d4efc5d9e677e3e0a4d4c98b7a8494ca0d3e65f0173i0",
+    "meta": {
+      "name": "bitcoiny00t #1"
+    }
+  },
+  {
+    "id": "762053f3961455c022a07c8e8f1dda5c2a141661524c16bbdadeff4b30d4f1e2i0",
+    "meta": {
+      "name": "bitcoiny00t #75"
+    }
+  },
+  {
+    "id": "791439c25d05b5488d1de966a39057423c9bf784848852531cb89892c5bf57e3i0",
+    "meta": {
+      "name": "bitcoiny00t #115"
+    }
+  },
+  {
+    "id": "7b85797cd659f2584bd2529412085080fe96854b18c183b121ad41a05043d97ci0",
+    "meta": {
+      "name": "bitcoiny00t #83"
+    }
+  },
+  {
+    "id": "7bd80f14d87c5e59cfa7ea4055a2047482cdd8d159a596b5b2c5afa522f3f953i0",
+    "meta": {
+      "name": "bitcoiny00t #24"
+    }
+  },
+  {
+    "id": "7c231452d8b3c7532a55d28dc05fbe260211ed78d18ceac33d054c0ed0355428i0",
+    "meta": {
+      "name": "bitcoiny00t #74"
+    }
+  },
+  {
+    "id": "7f8ffd07cd34b11914992be62d78234f4167afe85376a2fd61b2d32d4a9f4254i0",
+    "meta": {
+      "name": "bitcoiny00t #116"
+    }
+  },
+  {
+    "id": "80553e90a23f57b07befa99e34be532e297cb1fe3b5e3f011e22523939c31816i0",
+    "meta": {
+      "name": "bitcoiny00t #97"
+    }
+  },
+  {
+    "id": "8145dcdfe5515c513ae189e765f3b68d0ed3a2e61d3a3bb8eff4193f9966d90ci0",
+    "meta": {
+      "name": "bitcoiny00t #101"
+    }
+  },
+  {
+    "id": "8383ee0a0c909746c3eb743a0435f026403f0fd52099cecb6701d8d804b2f272i0",
+    "meta": {
+      "name": "bitcoiny00t #44"
+    }
+  },
+  {
+    "id": "876e812ac989489441f971dd1e4d855c12f873dd5dcba0cbce6d507d4ab327f6i0",
+    "meta": {
+      "name": "bitcoiny00t #88"
+    }
+  },
+  {
+    "id": "88310f20953048768bf815005b697be104e275993cb1898bce4e5a8697a98a6bi0",
+    "meta": {
+      "name": "bitcoiny00t #27"
+    }
+  },
+  {
+    "id": "8a59825a9cedfd4a6dc8fce2846b6c0d51186cd531d079a0243ec3309adea3ebi0",
+    "meta": {
+      "name": "bitcoiny00t #36"
+    }
+  },
+  {
+    "id": "8b5d02c0a97582e7908f0ffcfe59474745602daeffd0a7abf354f5fb18c35188i0",
+    "meta": {
+      "name": "bitcoiny00t #100"
+    }
+  },
+  {
+    "id": "8d2682172988e0229d4d0d903db0edcb4bf64c45e256c75f5ddb389c49ed56fbi0",
+    "meta": {
+      "name": "bitcoiny00t #58"
+    }
+  },
+  {
+    "id": "8e26b0a8b039fb73639ffef5b635af9bf159c791b6650136176e06106eb382f7i0",
+    "meta": {
+      "name": "bitcoiny00t #67"
+    }
+  },
+  {
+    "id": "8ea10f2878493e3e81c9dca567952354398f4944116b6b709a43fa65d0706655i0",
+    "meta": {
+      "name": "bitcoiny00t #40"
+    }
+  },
+  {
+    "id": "90bffdbaf268c3575887ae5c13a76db8340fde02cdd2906a9922684f736bb8c7i0",
+    "meta": {
+      "name": "bitcoiny00t #12"
+    }
+  },
+  {
+    "id": "916dfbeca694a67547240df51713652db9d34ebd8ebbc0ce6816d34786c90fdfi0",
+    "meta": {
+      "name": "bitcoiny00t #43"
+    }
+  },
+  {
+    "id": "9beea8ae62065294d4df7e00ab38a5d479498dd7b2737c06425a3881f4161e54i0",
+    "meta": {
+      "name": "bitcoiny00t #31"
+    }
+  },
+  {
+    "id": "9f6bc4ee885f6849b217d09bb854a2f3b390e3d8ea811d563ba8b75a0cbd079ei0",
+    "meta": {
+      "name": "bitcoiny00t #80"
+    }
+  },
+  {
+    "id": "a31d5df05a7025e287eedefaaef89f4579a314f1f33959cc6ae33900de30a096i0",
+    "meta": {
+      "name": "bitcoiny00t #70"
+    }
+  },
+  {
+    "id": "a39a48b2d04ef4d16f10e496c6d08bae442fa08983d4cecfc76661f1f8a576f1i0",
+    "meta": {
+      "name": "bitcoiny00t #35"
+    }
+  },
+  {
+    "id": "a6039d7223014e37587603aeeb4a7b1c10c94c3a3cfcc09af82349bd79b4358ai0",
+    "meta": {
+      "name": "bitcoiny00t #34"
+    }
+  },
+  {
+    "id": "a8b6323432136377232b8ed0865e5eb7a240fdde3560937472f95337c1fc30cai0",
+    "meta": {
+      "name": "bitcoiny00t #76"
+    }
+  },
+  {
+    "id": "ab321bc13b3e62da1b34691dfaf81451f9b524467ab3f6bab9d783e3ca0b57edi0",
+    "meta": {
+      "name": "bitcoiny00t #33"
+    }
+  },
+  {
+    "id": "af565141d8faa7f9a5a8f9ae735f14c5dad7519e4d28e2147c1668b1ba6be55ci0",
+    "meta": {
+      "name": "bitcoiny00t #14"
+    }
+  },
+  {
+    "id": "b8c99d1630ea30678a361dd60aabef9eb10c5412dc1de514cf52d5a1f5c013c5i0",
+    "meta": {
+      "name": "bitcoiny00t #77"
+    }
+  },
+  {
+    "id": "ba438dd08ee001052aaf3cc21866997d1fb57550c3c1c73f12c322b06e46182bi0",
+    "meta": {
+      "name": "bitcoiny00t #79"
+    }
+  },
+  {
+    "id": "ba7f4930cf4f09846c2d4d9fd6e073928f4c69f51b1834208a8569fb6fbe55dbi0",
+    "meta": {
+      "name": "bitcoiny00t #17"
+    }
+  },
+  {
+    "id": "bd83117c3ae34619cb1b3fbaba21382764e66b33fb8bf85fb85c26d381e11609i0",
+    "meta": {
+      "name": "bitcoiny00t #59"
+    }
+  },
+  {
+    "id": "c235b4be681a903211c593358067fa9071fbe45384669656df387e1d60fee21di0",
+    "meta": {
+      "name": "bitcoiny00t #38"
+    }
+  },
+  {
+    "id": "c51b6c7595349b86bdf2bd610404d7b3171b9440c56d485e940ac53482bd6205i0",
+    "meta": {
+      "name": "bitcoiny00t #55"
+    }
+  },
+  {
+    "id": "c9056ebe30e51bf707759afca2865db8dd97cd2dad17c90a3bade83c8e091ffdi0",
+    "meta": {
+      "name": "bitcoiny00t #72"
+    }
+  },
+  {
+    "id": "c94f52a99a32ae6a0410b5bbf3e6efaba3712f9746d5954a7f5854896e9eab2fi0",
+    "meta": {
+      "name": "bitcoiny00t #18"
+    }
+  },
+  {
+    "id": "cd3201e3d718e44815b2a07befb37d54ab5ff48b1867318353d3a2556919cb37i0",
+    "meta": {
+      "name": "bitcoiny00t #64"
+    }
+  },
+  {
+    "id": "cff5c3cf4ec67bf4160ac9d0d2ebb0717a15a4d90f97d7ab327691dcec62e6b5i0",
+    "meta": {
+      "name": "bitcoiny00t #53"
+    }
+  },
+  {
+    "id": "d1d6d563066b851d788320647b648d25aa67e982e372e53edb06bf4b4af1dbdei0",
+    "meta": {
+      "name": "bitcoiny00t #39"
+    }
+  },
+  {
+    "id": "d65e9f7a8cd6ee4f09f6d172d036ee56d55c01bea3ca45e528bc323b725877edi0",
+    "meta": {
+      "name": "bitcoiny00t #52"
+    }
+  },
+  {
+    "id": "db337b60fef280b6014a200f235f7b42301ae4661f3e6c13889f972199f97e9ci0",
+    "meta": {
+      "name": "bitcoiny00t #103"
+    }
+  },
+  {
+    "id": "dc6bcf50c3ba9f23b4647bf28bb8754e9a1ede91779627f358da4661055a9dcai0",
+    "meta": {
+      "name": "bitcoiny00t #47"
+    }
+  },
+  {
+    "id": "de0ea74d7afe19f8a71dbdc6377ca9f31c81c9a7f6c016e61235953d7162f2c9i0",
+    "meta": {
+      "name": "bitcoiny00t #68"
+    }
+  },
+  {
+    "id": "de6dacbb8840ab3e52991778bb2e1f69633291dd971459af9899ed6ff2c3f4c3i0",
+    "meta": {
+      "name": "bitcoiny00t #26"
+    }
+  },
+  {
+    "id": "e19a934a0d2792cca9829b3a3926501ccebcec06dcdd5b4bb70145d2fb83d1d9i0",
+    "meta": {
+      "name": "bitcoiny00t #41"
+    }
+  },
+  {
+    "id": "e3e26b7cfd9b3b8a0a7d84a785a20ea3a4ebd88d544fef6e170a76333ad91c7ei0",
+    "meta": {
+      "name": "bitcoiny00t #69"
+    }
+  },
+  {
+    "id": "e482b0c3a80ef12dfb6cd1603196ffd81c5df289bbcf18dea8fd8fcf65a15198i0",
+    "meta": {
+      "name": "bitcoiny00t #85"
+    }
+  },
+  {
+    "id": "e8f0511dd06f2e0c3bd744548171fef315d90625f826ea4a2e01d36893425c08i0",
+    "meta": {
+      "name": "bitcoiny00t #65"
+    }
+  },
+  {
+    "id": "eb2203bbcb5457119e42910341f6267b5d26aa88917a88fce459786066d8f9f0i0",
+    "meta": {
+      "name": "bitcoiny00t #86"
+    }
+  },
+  {
+    "id": "ebd81216addbfd9a15ec1c6d3d973a5101828adfea801d501af8e30aede24b8ai0",
+    "meta": {
+      "name": "bitcoiny00t #89"
+    }
+  },
+  {
+    "id": "ee234a097da44bca9fc374a77ff747b6b6ea88d7d6ddda9174897b662ff6b64ei0",
+    "meta": {
+      "name": "bitcoiny00t #49"
+    }
+  },
+  {
+    "id": "ef5cd1d5f0a72a4ee9a91064a67cf672ffd7284c9e7756bc28cc692fc0382ab2i0",
+    "meta": {
+      "name": "bitcoiny00t #118"
+    }
+  },
+  {
+    "id": "f0588c5df751413c835a75d2c1b05015cecf12bd399109d418517920a87cbdfci0",
+    "meta": {
+      "name": "bitcoiny00t #9"
+    }
+  },
+  {
+    "id": "f461d11d48848215fc3811235617571c1ced2d3a4663078ef11768f73bd8726di0",
+    "meta": {
+      "name": "bitcoiny00t #119"
+    }
+  },
+  {
+    "id": "fb3a8382469a5ec110a30d6b5e4fe754862c6115435e623a77f32711d638daf1i0",
+    "meta": {
+      "name": "bitcoiny00t #51"
+    }
+  }
+]

--- a/collections/bitcoiny00ts/meta.json
+++ b/collections/bitcoiny00ts/meta.json
@@ -1,0 +1,10 @@
+{
+  "description": "A collection of 535 btcy00ts inscribed on the Bitcoin blockchain.",
+  "discord_link": "",
+  "icon": "https://creator-hub-prod.s3.us-east-2.amazonaws.com/ord-y00tboys_pfp_1690207838076.png",
+  "inscription_icon": "9c32c4ee32d3420150ad74636896c275b78e759b52d2e28a2a9cd0a91e901a3bi0",
+  "name": "bitcoiny00ts",
+  "slug": "bitcoiny00ts",
+  "twitter_link": "https://twitter.com/Ordinalsy00ts",
+  "website_link": "https://btcy00ts.com/"
+}


### PR DESCRIPTION
double listing on website as /y00tboys and /bitcoiny00ts!  therefore metadata moved here from deleted collections/y00tboys dir, see pr #3801, now only 1 listing should remain.