### PR TITLE
Punks On Bitcoin - Update inscriptions.json

### DIFF
--- a/collections/punksonbitcoin/inscriptions.json
+++ b/collections/punksonbitcoin/inscriptions.json
@@ -192,7 +192,7 @@
     }
   },
   {
-    "id": "42e4ab2a38019e193f1f50ff914addcf99f5f943776df1abae33033c21501ca3i0",
+    "id": "8aaff57853ff16b43401dd0e619ee29c59a2606117dc5ebd38f235f6e324adf4i0",
     "meta": {
       "name": "Punk on Bitcoin #6"
     }


### PR DESCRIPTION
42e4ab2a38019e193f1f50ff914addcf99f5f943776df1abae33033c21501ca3i0  shouldn't have been in this listing, since it's one of the Punks erroneusly sent to a Binance hot wallet and replaced in the actual collection by a new inscription. His replacement, 8aaff57853ff16b43401dd0e619ee29c59a2606117dc5ebd38f235f6e324adf4i0  was mistakenly left out.

For reference: this is the address where are now sitting the lost Punks: bc1q2n3gy6hej8qt69ng98894x8ugukcmnqamvxx4f.  One of them is the aforementioned "42e4ab2a38019e193f1f50ff914addcf99f5f943776df1abae33033c21501ca3i0"

This change is proposed by the new team that recently acquired the collection from the original founder.