### PR TITLE
Add RIBBIT Flags

### DIFF
--- a/RIBBIT_Flags_inscriptions.json
+++ b/RIBBIT_Flags_inscriptions.json
@@ -1,0 +1,1918 @@
+[
+  {
+    "id": "457d07c3ae1ae2e5d274f424c5db82749237ce97f4faea010fe3ea77a5bed69ai0",
+    "meta": {
+      "name": "RIBBIT Flags #1",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Night"
+        }
+      ]
+    }
+  },
+  {
+    "id": "59ee070b177ebd4e6609f3e9208207ab2cf1ab9777ed141372294c196b76ed3di0",
+    "meta": {
+      "name": "RIBBIT Flags #2",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Sunny"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0f412aeb3f09c9010c2d9846b9e2d3b19af36acf12abd971b1bc4ba4e6e9d0cci0",
+    "meta": {
+      "name": "RIBBIT Flags #3",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Snow Mountain"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3251f4df33b15e092936f6723bd02d1e501880428445ec295c4f46d4653d8850i0",
+    "meta": {
+      "name": "RIBBIT Flags #4",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "ToDaMoon"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f7aaf7e9f01afd2cf73dba1fc75963a0f0af9360eec2e84e8829a42e75abb288i0",
+    "meta": {
+      "name": "RIBBIT Flags #5",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Pride Love"
+        }
+      ]
+    }
+  },
+  {
+    "id": "911c315d32268182601eee82d2c607d1c8f692d44855b6844989a7814c472b24i0",
+    "meta": {
+      "name": "RIBBIT Flags #6",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Summer Rain"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6b5ced961097555118cf7147f3375ad99b6500b90151ff4d5e82d8f293311a8ci0",
+    "meta": {
+      "name": "RIBBIT Flags #7",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Rainbow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "73afa3d1e35c3f0779220bb23972568dd2672e490aabf53b4b45666fffd3ae22i0",
+    "meta": {
+      "name": "RIBBIT Flags #8",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Frog Castle"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c5b4a31207c0192fdd4fd95e3a3caeac9abe7ca9f9443f600bc7a81b65112064i0",
+    "meta": {
+      "name": "RIBBIT Flags #9",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Marine"
+        }
+      ]
+    }
+  },
+  {
+    "id": "076031a746fbe5028796a16ea0837d822ee88c90e44e5daec2cc188213c53060i0",
+    "meta": {
+      "name": "RIBBIT Flags #10",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Pink World"
+        }
+      ]
+    }
+  },
+  {
+    "id": "35730f3f00b9b398e0be0fdc3bed4a69877a577faacd09cd7fac4fe207946b32i0",
+    "meta": {
+      "name": "RIBBIT Flags #11",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Mountains"
+        }
+      ]
+    }
+  },
+  {
+    "id": "64c326a7198d54a304c0dd0cbd6e467e3da7c3de3c6e2504a7e8dc52096c0cd8i0",
+    "meta": {
+      "name": "RIBBIT Flags #12",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "Bitcoin"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4923d54cd053a4ce5d90aca155b6ad54c0a1882e3aa4bd21f731ab10f4a83915i0",
+    "meta": {
+      "name": "RIBBIT Flags #13",
+      "attributes": [
+        {
+          "trait_type": "Special Flags",
+          "value": "The Starry Night"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a49e38851f14952b5e831c38e331793d0c5e086ef6950d0a6e292c9e4262dd71i0",
+    "meta": {
+      "name": "RIBBIT Flags #14",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ea51383bd478b17be3783de6acd08db295f6f3dc235f7901787278e3b175baf7i0",
+    "meta": {
+      "name": "RIBBIT Flags #15",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6fec1f1f7594b2ed02a442d1b4a19698ebd547da11e6644732b9e89238f684b4i0",
+    "meta": {
+      "name": "RIBBIT Flags #16",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9c892fbd8d4276c0f9867968451560b567957521662517daf5a9138536d05bd3i0",
+    "meta": {
+      "name": "RIBBIT Flags #17",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0cc0a9d4f4b55b0a0e49731278cca0cf813c3eb9bbbfeaadadf6107a1b82b333i0",
+    "meta": {
+      "name": "RIBBIT Flags #18",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ec45975713366683c2347fc9c6ead1efde9f4d0ecfe108d9b1097178c6170d27i0",
+    "meta": {
+      "name": "RIBBIT Flags #19",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5cacdb20f06a171c55f59f0cc608280484c1ebf05e029e2f0b43b4e78d39daf2i0",
+    "meta": {
+      "name": "RIBBIT Flags #20",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "022079674fcfc5e478bb5ac871956bfc4fb8804e3009f44207f230c94ad1b173i0",
+    "meta": {
+      "name": "RIBBIT Flags #21",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Bitcoin Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3c511cbe8c35851476cf9be83c7ad6f7b549110269c5ecb1be023280158eef15i0",
+    "meta": {
+      "name": "RIBBIT Flags #22",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fc14f18373c3d377c9af9df31e4551d95e886ec65b702cab7e98da1e3bc162fai0",
+    "meta": {
+      "name": "RIBBIT Flags #23",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d8e9acfdafb68e7c5ca7e343562bcd9f5ed8e52952eab1758a789f709d382559i0",
+    "meta": {
+      "name": "RIBBIT Flags #24",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "60c54099a6ff45192714af0ca4d418c7a023986d786a6b76e5cb6be088f1dd9bi0",
+    "meta": {
+      "name": "RIBBIT Flags #25",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "033ad2cc03b8f9cbf738b01ceecc3e4fc2d63757d37961a1c54f50209ae93d02i0",
+    "meta": {
+      "name": "RIBBIT Flags #26",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eee105cb8ff26e35eecee32f3680eb968d52f7a54ea05f3a5501f6569f8c113ai0",
+    "meta": {
+      "name": "RIBBIT Flags #27",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d7b26cf9f316b8f8fc9db2c836db2c6850a45dc56ea28ecede32bb03022dea28i0",
+    "meta": {
+      "name": "RIBBIT Flags #28",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "323ec2477da26352c22065a37b42c1018e95a75a7b0035c09db17a66133535ebi0",
+    "meta": {
+      "name": "RIBBIT Flags #29",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Sky Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7b1232f3e02297b4834cc9fecc21983f55265dae652afcf599d999bc540a15dai0",
+    "meta": {
+      "name": "RIBBIT Flags #30",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a0cf32543b82b135c73390f310080d22206fc0686a287c2e44d277dea3e012a3i0",
+    "meta": {
+      "name": "RIBBIT Flags #31",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c880c76db5795e213d0be69e0c4e83555a9cdbbeecdd57d1d79a9b0eec40734ei0",
+    "meta": {
+      "name": "RIBBIT Flags #32",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4ad067f8bc7447b684b2169ed3889f5202e272d287b4e99d43c63fd0f1fe583fi0",
+    "meta": {
+      "name": "RIBBIT Flags #33",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "779704c48f691312ecaa1d586356b497485d8ca89628c0aae1cfbeea3f741dc6i0",
+    "meta": {
+      "name": "RIBBIT Flags #34",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "af04090220cdd9c487a66bb24c8a5c9f9e7c3e8859206c5efdc152c527db6caci0",
+    "meta": {
+      "name": "RIBBIT Flags #35",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "127dfa3f4cf8a3449c8264a970a30de6f6ab6b365014ae0b0e6977baae95244ai0",
+    "meta": {
+      "name": "RIBBIT Flags #36",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f35bb6226eb7df897db585032ea9d1a8685f3a1985461fe8c3ec85d2682a2c49i0",
+    "meta": {
+      "name": "RIBBIT Flags #37",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "de3f0cc635dbf67d3235d907d1e1b9a3f620ffd318e004374f06eaf6d7270f7ci0",
+    "meta": {
+      "name": "RIBBIT Flags #38",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Black"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ba966e8e1ae1df53738bbc7ab21fd76c92d6d52539beacc290cdf3c071c4c0d5i0",
+    "meta": {
+      "name": "RIBBIT Flags #39",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "167551291d211925f0d14f1a2e83d887bfd507d9b0719460b828c9b67caeb6f2i0",
+    "meta": {
+      "name": "RIBBIT Flags #40",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cc757508aefab548e5d41d832a4e92bf6c515678c3afbfa0b2a1183bc16d6d27i0",
+    "meta": {
+      "name": "RIBBIT Flags #41",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a3d514c6127072b502171771b5f69951ba3c77a4e91e79e23f087bce4c0104bai0",
+    "meta": {
+      "name": "RIBBIT Flags #42",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "903bdab00106a285f1ef123f6d58ffabd71ac2992d59ece8c302e48073fabd65i0",
+    "meta": {
+      "name": "RIBBIT Flags #43",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "565b3cc05b6a6477f41e3d4202bb2e713e16c098d72284e75a8e238e030c1ad3i0",
+    "meta": {
+      "name": "RIBBIT Flags #44",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a577e8f7fd3242b715cb31837da987ffc2ede17f63a72d45a0bddee3dce520c5i0",
+    "meta": {
+      "name": "RIBBIT Flags #45",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a8922853cf30ccb6a4b4211eea4bd2314d1bc5a56422b2b6d8e421e7621be26di0",
+    "meta": {
+      "name": "RIBBIT Flags #46",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "83c150cdd8ecd15a78cdf08ecd2e4ed4974a94e7050eb8e079b0c35dd8d86bb1i0",
+    "meta": {
+      "name": "RIBBIT Flags #47",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Brown"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "24d9a1b0e529d2424cb2918c52ab36bf86a5f656ed25b90f6cbe7e0b7596df0bi0",
+    "meta": {
+      "name": "RIBBIT Flags #48",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "507a9594c38d54febf262e059edbe93312c575770434591a0c36037d7cd5b210i0",
+    "meta": {
+      "name": "RIBBIT Flags #49",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e910ece2f52535c1300afe68221180e4e7950bab72cc53d25e4de3a53eb30b4di0",
+    "meta": {
+      "name": "RIBBIT Flags #50",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8903adaaa77fc21d6416c91d2c36fc9309a19d0c568acbdc06c81d932e2a1badi0",
+    "meta": {
+      "name": "RIBBIT Flags #51",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "85fa0c72ad9bb070c2ff5f93b5d36492e799539bbf78b8d6fcd1f920a64b61f7i0",
+    "meta": {
+      "name": "RIBBIT Flags #52",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "848ff60a5a2ebec137e1087d8df4baa4765aec5013dd73a66169691a922e0215i0",
+    "meta": {
+      "name": "RIBBIT Flags #53",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0617d738ffb20475d837398577e1330fba476d943a8c34f8373db8aabbed4ffdi0",
+    "meta": {
+      "name": "RIBBIT Flags #54",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7ce7abb28ed8740e31d3d18b5ca89100a2665d78e8bcda86198e79a27423d38di0",
+    "meta": {
+      "name": "RIBBIT Flags #55",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Purple"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f018350d07e05746280202021e65bfa88c6f5c74aca4ab2f39ee255a01e5d36ci0",
+    "meta": {
+      "name": "RIBBIT Flags #56",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e3298961029ce5925b2fda3de84f4140a8ac1770165d58276e794ebc66a21be4i0",
+    "meta": {
+      "name": "RIBBIT Flags #57",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "231bf1babbd789ff627131ba93de96ecbc8616aaa55f1f9e7e152aac618712bci0",
+    "meta": {
+      "name": "RIBBIT Flags #58",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "69dba8cb54e6bc8fa00b232916101c3e89c18fcdc08eabeeb3bf3ade103d65efi0",
+    "meta": {
+      "name": "RIBBIT Flags #59",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2328a08474f00a4de181fd358f0c854ad969562e5d4db90442aeae32a21f2faei0",
+    "meta": {
+      "name": "RIBBIT Flags #60",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a391b9f34cee69241b17dfa27886a07c6e34ba00217fa15827fcf6ec641b4747i0",
+    "meta": {
+      "name": "RIBBIT Flags #61",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb15bdd7f25ddb1507da5c1ad08d8640d1e41a5e16c2eb110765d6fef4464487i0",
+    "meta": {
+      "name": "RIBBIT Flags #62",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "84537ac509e6a2f12854f39da997b589d4e4e1e96dfcc1dce0818491c3b2b689i0",
+    "meta": {
+      "name": "RIBBIT Flags #63",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d1dbe8eda6fc66c37ba8f75a97d6ebd6a40e26972bad2c5fc6a94bfffd6739e4i0",
+    "meta": {
+      "name": "RIBBIT Flags #64",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Grey"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "feb8cd3b8efb8771be30a1a95bd925412d9e7c3a8c63b9a0bd05dbcb42fffe40i0",
+    "meta": {
+      "name": "RIBBIT Flags #65",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "583436064c6bb1ba5860109626ec97f1edf0ac1c8bec0a7d2978f57768274ac7i0",
+    "meta": {
+      "name": "RIBBIT Flags #66",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "de87f46a7770a37107fd3567a4d7a037e1b79af61fee8190c15c076d5d6c0ff9i0",
+    "meta": {
+      "name": "RIBBIT Flags #67",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c035e86f66e709978bade7cb3184e56744f0707134b62ddf01f6393df7599df3i0",
+    "meta": {
+      "name": "RIBBIT Flags #68",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6d718554ef32a685aeae64262873fd591ea970eda4e95a8b9738e27f21f44ad7i0",
+    "meta": {
+      "name": "RIBBIT Flags #69",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7a427f7d0820ccb9ba7484fcc48d0caf9da2297d1880439ebbc9b986be2f1283i0",
+    "meta": {
+      "name": "RIBBIT Flags #70",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bdaf02cd571f49cbd054b078b4168494b7fc8fdac558ef6a88efc06a0c70d339i0",
+    "meta": {
+      "name": "RIBBIT Flags #71",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bc9cbd7d4c37142fb39121740f307c11feb0356e71fa5424c8bef6d67889d203i0",
+    "meta": {
+      "name": "RIBBIT Flags #72",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bfaf4e7b02f9ba535014087aa4403a64591e45045b2a2ee4a0c62172149caffdi0",
+    "meta": {
+      "name": "RIBBIT Flags #73",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d1f7397a9a21b199b517f9b26b8d8a5d80ddbd7116039d7106608a1639d201fei0",
+    "meta": {
+      "name": "RIBBIT Flags #74",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "144a27dd733bfd50cc405b7e7020fd6aa4aa2e0ac7b376850f99b6de33343ad4i0",
+    "meta": {
+      "name": "RIBBIT Flags #75",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1648a516dd2d2394a21366676f9480346954d10c15c92a732977cda00f77a954i0",
+    "meta": {
+      "name": "RIBBIT Flags #76",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "859f81932d08f5f3935cdc591fcdcaadb7e7f6d2bcae1841733632ed21db10f6i0",
+    "meta": {
+      "name": "RIBBIT Flags #77",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4f6f3752817f3d1fdd1deb43ab9a55db6dcd89d17ded58acb749774e88390b80i0",
+    "meta": {
+      "name": "RIBBIT Flags #78",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d9f38680e005713a443b5788770abf9fc2d9d320913fde7590c055f50383df56i0",
+    "meta": {
+      "name": "RIBBIT Flags #79",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8275ce8f0d49aead6267ba4ce8c9e8e3262a30b3ce9fb83b9277df1213087a0fi0",
+    "meta": {
+      "name": "RIBBIT Flags #80",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Green"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9e208eddb7ec806359360c79c0aece7afaab81b2a60af7aa07d528dd869b71a5i0",
+    "meta": {
+      "name": "RIBBIT Flags #81",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b63c10d1a2b4c831c53d0f3ac3e142a33d8380c60d1bce05434da5681eb763bei0",
+    "meta": {
+      "name": "RIBBIT Flags #82",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2401bacb2a362e8caf2aa07a6237f3b81825b1c7eef6d67c4b3780ba8216a5aci0",
+    "meta": {
+      "name": "RIBBIT Flags #83",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "210c6cff702627496c8a17eecffedd091c059a673c6efc9b2941fdd907186ceei0",
+    "meta": {
+      "name": "RIBBIT Flags #84",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a65c662d1f892aa26e7415ab81c2de6265f0a73313e15c4b1e83c0c107f56a19i0",
+    "meta": {
+      "name": "RIBBIT Flags #85",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "944239cbabf814d1c052388d70547269c5d6e1e942877fa06ce2e310ca6d4c0ci0",
+    "meta": {
+      "name": "RIBBIT Flags #86",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0e05086e3a0acebae5e00a6f5149d895f387a2be3a989c6d908971527566eebai0",
+    "meta": {
+      "name": "RIBBIT Flags #87",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e5834c6390780682607953153fe0ab2c44a7cf6b4723832e173564e1fa9f6645i0",
+    "meta": {
+      "name": "RIBBIT Flags #88",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a368cff83a68f2498a17e351d209aa4733adf86de0d15beb9fd470419f6c209fi0",
+    "meta": {
+      "name": "RIBBIT Flags #89",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5c41e5af4d160b8f4d912edef195d93cf3f0da6da814b9f58b8e88eb1b941591i0",
+    "meta": {
+      "name": "RIBBIT Flags #90",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a56b3cdd0a8485e3fe11f108e1b1a8aad5faa55997714533fbe4b77f6272bd70i0",
+    "meta": {
+      "name": "RIBBIT Flags #91",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cca4befa418a142c6001b207547b7de60699caa6b0d331cc8e060a009a7ede5fi0",
+    "meta": {
+      "name": "RIBBIT Flags #92",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f8801471b04ba462f076f8e7205710f19431b66cc9c21662ebb219426d8732d5i0",
+    "meta": {
+      "name": "RIBBIT Flags #93",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b6e591e10b8f8e17ca569a6b0e8e60e574bd94774dfd555679b6938502f25111i0",
+    "meta": {
+      "name": "RIBBIT Flags #94",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "58a934f886a4a47b25001e17cecbca7807263c5f995c7354c589bb39aea87d97i0",
+    "meta": {
+      "name": "RIBBIT Flags #95",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c175e94073b06fc8bb878e70907eeebd5a47423c7c0da0e1c588df9db64863d8i0",
+    "meta": {
+      "name": "RIBBIT Flags #96",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dbcb7d7e242cecdac1834a2197c00b71a5f2b3dfdda171b90d1f212f2cd53985i0",
+    "meta": {
+      "name": "RIBBIT Flags #97",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "01741f0260d12df49851afd7cbc69062ac269aeea859d4382d2a9c2e2d703167i0",
+    "meta": {
+      "name": "RIBBIT Flags #98",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Pink"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d9f3b3e8027812380734147ad1394cea8dd6655a1257a4027150ce396bd9ed99i0",
+    "meta": {
+      "name": "RIBBIT Flags #99",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c8fb3d63ff19010dc7b6225f55826bd7ba400fd6c6b2e95c32d99e88efb13657i0",
+    "meta": {
+      "name": "RIBBIT Flags #100",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7260adc7e996c44b3838b673a64b470f3f3e8ba9f051aa5f8b97ae5fda61721fi0",
+    "meta": {
+      "name": "RIBBIT Flags #101",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3425034de83bb1a4f73a2c3fb68cdea3b80c0f2e8079a9683a02f2b9b7a06bf5i0",
+    "meta": {
+      "name": "RIBBIT Flags #102",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dca9678a9efe2751cb8a41bfd4903babf9176c517acc89cdc32ab5c5b9acc1cfi0",
+    "meta": {
+      "name": "RIBBIT Flags #103",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5ffa959c5b60f32a3a399b4a568ed04cbe905f728f8c6bac9da1f0b8a41047b3i0",
+    "meta": {
+      "name": "RIBBIT Flags #104",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cc32707074da3261bd8787d592230988508aa7f6936497a9d0d12440a4d47a34i0",
+    "meta": {
+      "name": "RIBBIT Flags #105",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0a2e8e1e7480870f6c5f5c3449ca0170460b452296cda9c2661c69b11e88f65fi0",
+    "meta": {
+      "name": "RIBBIT Flags #106",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Light Red"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c7fa0fe9e9963fc3cd4ad03d8e64659fe94ea96d82fdb6958edd7afcfef5a810i0",
+    "meta": {
+      "name": "RIBBIT Flags #107",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "350c16f188acef9df739a0c45ebf9c0affd4b1bfd2e6f7b781ab8a358f87fd09i0",
+    "meta": {
+      "name": "RIBBIT Flags #108",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "021f694a544d8c02e780480b59441b9b56e0bfb71a311bdc15e7b70709e6ea11i0",
+    "meta": {
+      "name": "RIBBIT Flags #109",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "827d17412fb2a7fb26e3975701aeaadc5b567d0a78a625aeaec744236c9a5cc3i0",
+    "meta": {
+      "name": "RIBBIT Flags #110",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "812e35a11a9e9a5d32832114669701c2234c7be530362b266d67fee1410d1b15i0",
+    "meta": {
+      "name": "RIBBIT Flags #111",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "af0e33b635be17f2b3a29484c99753c224b6bddaf09d03153e833e720a08d663i0",
+    "meta": {
+      "name": "RIBBIT Flags #112",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c1901c7b3150a88c6446f55e8c091c349bcf86a458f32979d20c9d9c675d576bi0",
+    "meta": {
+      "name": "RIBBIT Flags #113",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d821b6fb81cb58b6016f931f36b6e4c1b08d78fd06502e49c250bb6e97a25f3ei0",
+    "meta": {
+      "name": "RIBBIT Flags #114",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Red"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d9c9a0ee48eb87820d59b0545c3dd67ef069b972f414ea38393a25eb3dbfe490i0",
+    "meta": {
+      "name": "RIBBIT Flags #115",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Yellow"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  },
+  {
+    "id": "918a434460a84004568b9ff000ba2c4cc0341d5578cd197f021231770afaf259i0",
+    "meta": {
+      "name": "RIBBIT Flags #116",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Pink"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6b8a3462bec1841ee40790ef18a65ae05637d47b97df69bf29eaec94bb446afci0",
+    "meta": {
+      "name": "RIBBIT Flags #117",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Bitcoin Orange"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1d2d74aa533545baaf9bfa4f5a385a065eec3d753ca7e36954e02786bfb94cf8i0",
+    "meta": {
+      "name": "RIBBIT Flags #118",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Yellow"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9a8f04aa9e0602021242ddda880a1f56c8565c9d5080a6032228819a2f66cfd4i0",
+    "meta": {
+      "name": "RIBBIT Flags #119",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Green"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4765ff46e9bb5dc1740330f1dcf4a484203fd52def87f228c919b11eaf5dce10i0",
+    "meta": {
+      "name": "RIBBIT Flags #120",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Olive"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4b9c5fd4c1f3d324e89074744a0fe3ceeab91725f6327f16aafacce852ce9282i0",
+    "meta": {
+      "name": "RIBBIT Flags #121",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Light Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "444c168434cc423cb2c070c9c7fc3a40c67168bccb655842dda763494bc55890i0",
+    "meta": {
+      "name": "RIBBIT Flags #122",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Blue"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7a0c528eb83c45f55f51965fdf7803fdf17163296ed6f9ada253507738cd8daci0",
+    "meta": {
+      "name": "RIBBIT Flags #123",
+      "attributes": [
+        {
+          "trait_type": "Background",
+          "value": "Blue"
+        },
+        {
+          "trait_type": "Flag color",
+          "value": "Purple"
+        }
+      ]
+    }
+  }
+]

--- a/RIBBIT_Flags_meta.json
+++ b/RIBBIT_Flags_meta.json
@@ -1,0 +1,8 @@
+{
+  "name": "RIBBIT Flags", 
+  "inscription_icon": "fc14f18373c3d377c9af9df31e4551d95e886ec65b702cab7e98da1e3bc162fai0", 
+  "supply":"123",
+  "slug": "ribbit-flags",
+  "description": "The design of RIBBIT Flags is inspired by Bitcoin Frogs. The colors and image sizes are the same as Bitcoin Frogs. They are created for the community, based only on joy and love, and exist permanently on the Bitcoin blockchain. Ribbit for Bitcoin Frogs, Ribbit for Ordinals, Ribbit for Bitcoin, Ribbit for a Bitcoin World! ",
+  "twitter_link": "https://twitter.com/btcwordi"
+}


### PR DESCRIPTION
The design of RIBBIT Flags is inspired by Bitcoin Frogs, with a total of 123, including 13 specially designed flags, the color and picture size are consistent with frogs, and are given away for free to the frog community who also love Bitcoin Frogs and #Ribbit together every day.
[RIBBIT_Flags_meta.json](https://github.com/ordinals-wallet/ordinals-collections/files/13624928/RIBBIT_Flags_meta.json)
[RIBBIT_Flags_inscriptions.json](https://github.com/ordinals-wallet/ordinals-collections/files/13624929/RIBBIT_Flags_inscriptions.json)
