### PR TITLE
Update meta.json

### DIFF
--- a/collections/chainspace/meta.json
+++ b/collections/chainspace/meta.json
@@ -1,6 +1,6 @@
 {
   "description": "Chainspace is a BTC-native infinite art machine — 800 fully on-chain, stateless web apps that transform the viewer into generative art. In Chainspace, you are the art.",
-  "discord_link": "https://discord.com/invite/chainspace",
+  "discord_link": "https://discord.gg/FkZr4Jc57J",
   "icon": "https://turbo.ordinalswallet.com/inscription/preview/a6e1a0f1dea5ac2f1eb366db2d037bdcfcbd6adfc88f91456656ae7848b049c0i0",
   "inscription_icon": "a6e1a0f1dea5ac2f1eb366db2d037bdcfcbd6adfc88f91456656ae7848b049c0i0",
   "name": "Chainspace",


### PR DESCRIPTION
The original Chainspace Discord had a custom URL (/chainspace) but lost it when our Boosts went below a threshold, and some hacker picked up the URL and now has an active wallet drainer in that Discord. Please accept this commit ASAP so that we can avoid more people getting drained.

DM me on Twitter @timshelxyz if you need confirmation that I'm the founder and this is accurate.